### PR TITLE
Enables unlike option

### DIFF
--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -302,6 +302,23 @@ defmodule Mindwendel.Brainstormings do
   end
 
   @doc """
+  Deletes a like for an idea by a given user
+
+  ## Examples
+
+      iex> add_like(1, 2)
+      {:ok, %Idea{}}
+
+  """
+  def delete_like(idea_id, user_id) do
+    Repo.delete_all(
+      from like in Like, where: like.user_id == ^user_id and like.idea_id == ^idea_id
+    )
+
+    {:ok, get_idea!(idea_id)} |> broadcast(:idea_updated)
+  end
+
+  @doc """
   Returns a subscibe result.
 
   ## Examples

--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -312,7 +312,9 @@ defmodule Mindwendel.Brainstormings do
   """
   def delete_like(idea_id, user_id) do
     # we ignore the result, delete_all returns the count of deleted items. We'll reload and broadcast the idea either way:
-    Repo.delete_all(from like in Like, where: like.user_id == ^user_id and like.idea_id == ^idea_id)
+    Repo.delete_all(
+      from like in Like, where: like.user_id == ^user_id and like.idea_id == ^idea_id
+    )
 
     {:ok, get_idea!(idea_id)} |> broadcast(:idea_updated)
   end

--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -306,14 +306,13 @@ defmodule Mindwendel.Brainstormings do
 
   ## Examples
 
-      iex> add_like(1, 2)
+      iex> delete_like(1, 2)
       {:ok, %Idea{}}
 
   """
   def delete_like(idea_id, user_id) do
-    Repo.delete_all(
-      from like in Like, where: like.user_id == ^user_id and like.idea_id == ^idea_id
-    )
+    # we ignore the result, delete_all returns the count of deleted items. We'll reload and broadcast the idea either way:
+    Repo.delete_all(from like in Like, where: like.user_id == ^user_id and like.idea_id == ^idea_id)
 
     {:ok, get_idea!(idea_id)} |> broadcast(:idea_updated)
   end

--- a/lib/mindwendel_web/live/idea_live/index_component.ex
+++ b/lib/mindwendel_web/live/idea_live/index_component.ex
@@ -18,4 +18,11 @@ defmodule MindwendelWeb.IdeaLive.IndexComponent do
 
     {:noreply, socket}
   end
+
+  @impl true
+  def handle_event("unlike", %{"id" => id}, socket) do
+    Brainstormings.delete_like(id, socket.assigns.current_user.id)
+
+    {:noreply, socket}
+  end
 end

--- a/lib/mindwendel_web/live/idea_live/index_component.html.leex
+++ b/lib/mindwendel_web/live/idea_live/index_component.html.leex
@@ -34,9 +34,9 @@
                 <i class="bi bi-arrow-up-circle"></i>
                 <% end %>
               <% else %>
-                <a href="#">
+                <%= link to: "#", phx_click: "unlike", phx_target: @myself, phx_value_id: idea.id, title: 'Unlike' do %>
                   <i class="bi bi-arrow-up-circle-fill"></i>
-                </a>
+                <% end%>
               <% end %>
             </div>
           </div>

--- a/lib/mindwendel_web/live/idea_live/index_component.html.leex
+++ b/lib/mindwendel_web/live/idea_live/index_component.html.leex
@@ -36,7 +36,7 @@
               <% else %>
                 <%= link to: "#", phx_click: "unlike", phx_target: @myself, phx_value_id: idea.id, title: 'Unlike' do %>
                   <i class="bi bi-arrow-up-circle-fill"></i>
-                <% end%>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -92,4 +92,20 @@ defmodule Mindwendel.BrainstormingsTest do
       assert count == 1
     end
   end
+
+  describe "delete_likes" do
+    test "deletes a like", %{idea: idea, user: user} do
+      # add a like first:
+      Brainstormings.add_like(idea.id, user.id)
+
+      count = idea |> assoc(:likes) |> Repo.aggregate(:count, :id)
+      assert count == 1
+
+      # delete like:
+      Brainstormings.delete_like(idea.id, user.id)
+
+      count = idea |> assoc(:likes) |> Repo.aggregate(:count, :id)
+      assert count == 0
+    end
+  end
 end

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -7,7 +7,8 @@ defmodule Mindwendel.BrainstormingsTest do
     %{
       brainstorming: Factory.insert!(:brainstorming),
       idea: Factory.insert!(:idea),
-      user: Factory.insert!(:user)
+      user: Factory.insert!(:user),
+      like: Factory.insert!(:like, :with_idea_and_user)
     }
   end
 
@@ -94,17 +95,15 @@ defmodule Mindwendel.BrainstormingsTest do
   end
 
   describe "delete_likes" do
-    test "deletes a like", %{idea: idea, user: user} do
-      # add a like first:
-      Brainstormings.add_like(idea.id, user.id)
-
-      count = idea |> assoc(:likes) |> Repo.aggregate(:count, :id)
+    @tag individual_test: "true"
+    test "deletes a like", %{like: like} do
+      count = like.idea |> assoc(:likes) |> Repo.aggregate(:count, :id)
       assert count == 1
 
       # delete like:
-      Brainstormings.delete_like(idea.id, user.id)
+      Brainstormings.delete_like(like.idea.id, like.user.id)
 
-      count = idea |> assoc(:likes) |> Repo.aggregate(:count, :id)
+      count = like.idea |> assoc(:likes) |> Repo.aggregate(:count, :id)
       assert count == 0
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -37,6 +37,13 @@ defmodule Mindwendel.Factory do
     }
   end
 
+  def build(:like, :with_idea_and_user) do
+    %Like{
+      user: build(:user),
+      idea: build(:idea)
+    }
+  end
+
   # TODO: extract to helper
   def build(factory_name, attributes) do
     factory_name |> build() |> struct!(attributes)
@@ -44,6 +51,10 @@ defmodule Mindwendel.Factory do
 
   def insert!(:brainstorming, :with_users) do
     build(:brainstorming, :with_users) |> Repo.insert!()
+  end
+
+  def insert!(:like, :with_idea_and_user) do
+    build(:like, :with_idea_and_user) |> Repo.insert!()
   end
 
   def insert!(factory_name, attributes) do


### PR DESCRIPTION
Enables unlike option - when hitting the like button of an upvoted idea again, the like of this user will be deleted.

Closes #16 