### PR TITLE
Bind schema to migration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,11 @@ defmodule Mindwendel.MixProject do
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      # This was necessary when executing `mix test` and was thrown by priv/repo/data_migrations/migrate_idea_labels.exs .
+      # The follwoing line avoids a warning in the test, see https://elixirforum.com/t/the-inspect-protocol-has-already-been-consolidated-for-ecto-schema-with-redacted-field/34992/14
+      # Apparently, it should have been resolved in the latest version of phoenix. But, we will see.
+      consolidate_protocols: Mix.env() != :test
     ]
   end
 

--- a/priv/repo/data_migrations/migrate_idea_labels.exs
+++ b/priv/repo/data_migrations/migrate_idea_labels.exs
@@ -42,7 +42,10 @@ defmodule Mindwendel.Repo.DataMigrations.MigrateIdealLabels do
 
   def migrate_labels_from_ideas do
     Repo.transaction(fn ->
-      from(Idea, preload: [:label, brainstorming: [:labels]])
+      from(Idea,
+        preload: [:label, brainstorming: [:labels]],
+        select: [:deprecated_label, :brainstorming_id, :label_id, :id]
+      )
       |> Repo.all()
       |> Enum.each(&migrate_label_to_idea_label/1)
     end)

--- a/priv/repo/data_migrations/migrate_idea_labels.exs
+++ b/priv/repo/data_migrations/migrate_idea_labels.exs
@@ -4,8 +4,64 @@ defmodule Mindwendel.Repo.DataMigrations.MigrateIdealLabels do
   import MindwendelWeb.Gettext
 
   alias Mindwendel.Repo
-  alias Mindwendel.Brainstormings.Brainstorming
-  alias Mindwendel.Brainstormings.Idea
+
+  defmodule IdeaLabel do
+    use Mindwendel.Schema
+
+    alias Mindwendel.Brainstormings.Brainstorming
+
+    schema "idea_labels" do
+      field :name, :string
+      field :color, :string
+      field :position_order, :integer
+
+      belongs_to :brainstorming, Brainstorming, foreign_key: :brainstorming_id, type: :binary_id
+
+      timestamps()
+    end
+  end
+
+  defmodule Brainstorming do
+    use Mindwendel.Schema
+    import MindwendelWeb.Gettext
+
+    alias Mindwendel.Repo.DataMigrations.MigrateIdealLabels.IdeaLabel
+
+    schema "brainstormings" do
+      field :name, :string
+      field :option_show_link_to_settings, :boolean
+
+      has_many :labels, IdeaLabel
+
+      timestamps()
+    end
+
+    def idea_label_factory do
+      [
+        %IdeaLabel{name: gettext("cyan"), color: "#0dcaf0", position_order: 0},
+        %IdeaLabel{name: gettext("gray dark"), color: "#343a40", position_order: 1},
+        %IdeaLabel{name: gettext("green"), color: "#198754", position_order: 2},
+        %IdeaLabel{name: gettext("red"), color: "#dc3545", position_order: 3},
+        %IdeaLabel{name: gettext("yellow"), color: "#ffc107", position_order: 4}
+      ]
+    end
+  end
+
+  defmodule Idea do
+    use Mindwendel.Schema
+
+    alias Mindwendel.Repo.DataMigrations.MigrateIdealLabels.Brainstorming
+
+    @label_values [:label_1, :label_2, :label_3, :label_4, :label_5]
+
+    schema "ideas" do
+      field :deprecated_label, Ecto.Enum, source: :label, values: @label_values
+      belongs_to :brainstorming, Brainstorming, foreign_key: :brainstorming_id, type: :binary_id
+      belongs_to :label, IdeaLabel, foreign_key: :label_id, type: :binary_id, on_replace: :nilify
+
+      timestamps()
+    end
+  end
 
   @deprecated_label_to_idea_label_name_mapping %{
     label_1: gettext("cyan"),
@@ -43,8 +99,7 @@ defmodule Mindwendel.Repo.DataMigrations.MigrateIdealLabels do
   def migrate_labels_from_ideas do
     Repo.transaction(fn ->
       from(Idea,
-        preload: [:label, brainstorming: [:labels]],
-        select: [:deprecated_label, :brainstorming_id, :label_id, :id]
+        preload: [:label, brainstorming: [:labels]]
       )
       |> Repo.all()
       |> Enum.each(&migrate_label_to_idea_label/1)

--- a/priv/repo/data_migrations/migrate_idea_labels.exs
+++ b/priv/repo/data_migrations/migrate_idea_labels.exs
@@ -98,9 +98,7 @@ defmodule Mindwendel.Repo.DataMigrations.MigrateIdealLabels do
 
   def migrate_labels_from_ideas do
     Repo.transaction(fn ->
-      from(Idea,
-        preload: [:label, brainstorming: [:labels]]
-      )
+      from(Idea, preload: [:label, brainstorming: [:labels]])
       |> Repo.all()
       |> Enum.each(&migrate_label_to_idea_label/1)
     end)


### PR DESCRIPTION
## Further details
- Migration need to be written in a way that is independent from the current schema or models <= this avoids faling migrations in a later point in time

## Checklist
- [x] Add models / schemas to migration
- [x] Fix migration