### PR TITLE
Adding usability improvements to brainstorming edit page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -45,10 +45,8 @@ Hooks.NativeSharingButton = {
       this.el.addEventListener('click', (event) => {
         navigator.share(shareData)
         .then() // Do nothing
-        .catch(err => { console.error(`${err}`) }) 
+        .catch(err => { console.log(`Error: ${err}`) }) 
       })
-    } else {
-      this.el.classList.add("d-none")
     }
   }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,7 @@ import NProgress from "nprogress"
 import {LiveSocket} from "phoenix_live_view"
 import QRCodeStyling from "qr-code-styling";
 import ClipboardJS from "clipboard"
+import {buildQrCodeOptions} from "./qrCodeUtils.js"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 
@@ -86,30 +87,6 @@ Hooks.Modal = {
     })
   }
 }
-
-const buildQrCodeOptions = (qrCodeUrl) => ({
-  backgroundOptions: {
-    color: "#fff",
-  },
-  cornersDotOptions: {
-    type: 'dot'
-  },
-  cornersSquareOptions: {
-    type: 'square'
-  },
-  dotsOptions: {
-    color: '#000000',
-    type: "dots",
-  },
-  imageOptions: {
-    crossOrigin: "anonymous",
-    margin: 20,
-  },
-  data: qrCodeUrl || "",
-  height: 300,
-  type: "svg",
-  width: 300
-})
 
 Hooks.QrCodeCanvas = {
   mounted() {

--- a/assets/js/qrCodeUtils.js
+++ b/assets/js/qrCodeUtils.js
@@ -1,0 +1,23 @@
+export const buildQrCodeOptions = (qrCodeUrl) => ({
+  backgroundOptions: {
+    color: "#fff",
+  },
+  cornersDotOptions: {
+    type: 'dot'
+  },
+  cornersSquareOptions: {
+    type: 'square'
+  },
+  dotsOptions: {
+    color: '#000000',
+    type: "dots",
+  },
+  imageOptions: {
+    crossOrigin: "anonymous",
+    margin: 20,
+  },
+  data: qrCodeUrl || "",
+  height: 300,
+  type: "svg",
+  width: 300
+})

--- a/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
+++ b/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
@@ -48,7 +48,7 @@
     <h4><%= gettext("Edit Brainstorming") %></h4>
   </div>
   <div class="card-body">
-    <%= f = form_for @changeset, "#", [phx_submit: :save, phx_change: :save] %>
+    <%= f = form_for @changeset, "#", [phx_submit: :save, phx_change: :save, id: "form-edit-brainstorming"] %>
       <div class="mb-3 position-relative">
         <%= label f, :name, class: "form-label" %>
         <%= text_input f, :name, class: "form-control #{if f.errors[:name], do: "is-invalid"} #{if f.source.changes[:name], do: "is-valid"}", phx_debounce: 500, phx_feedback_for: input_id(f, :name) %>

--- a/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
+++ b/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
@@ -1,10 +1,40 @@
-<div class="card">
+<div class="card mb-3">
 <div class="card-header">
   <h4><%= gettext("Administration for brainstorming: %{name}", name: @brainstorming.name) %></h4>
 </div>
 <div class="card-body">
   <p><%= gettext("Save this link to update / delete your brainstorming later on:") %></p>
-    <%= tag :input, id: "brainstorming-link", type: "text", class: "form-control", value: URI.to_string(@uri), aria_describedby: "basic-addon1", readonly: true %>
+    <div class="input-group">
+      <input
+        aria-describedby="brainstorming-link-copy-to-clipboard-button"
+        aria-label="Url to brainstorming"
+        class="form-control"
+        id="brainstorming-link-input-readonly"
+        readonly="true"
+        type="text"
+        value="<%= URI.to_string(@uri) %>"
+      />
+      <button
+        class="btn btn-outline-secondary"
+        data-clipboard-target="#brainstorming-link-input-readonly"
+        id="brainstorming-link-copy-to-clipboard-button"
+        phx-hook="CopyBrainstormingLinkButton"
+        type="button"
+      >
+        <%= gettext("Copy") %>
+      </button>
+      <button
+        aria-label="Share brainstorming"
+        class="btn btn-outline-secondary"
+        data-native-sharing-button-share-data-text="<%= gettext("Join my brainstorming") %>"
+        data-native-sharing-button-share-data-title="<%= gettext("Mindwendel Brainstorming") %>"
+        data-native-sharing-button-share-data-url="<%= URI.to_string(@uri) %>"
+        id="brainstorming-link-share-button"
+        phx-hook="NativeSharingButton"
+      >
+        <i class="bi-share-fill"></i>
+      </button>
+    </div>
     <br />
     <i class="far fa-arrow-alt-circle-right"></i>
     <%= link gettext("Proceed to your brainstorming"), to: Routes.brainstorming_show_path(@socket, :show, @brainstorming), class: "fw-bold" %>
@@ -94,8 +124,83 @@
     <hr />
     <p><%= gettext("Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone") %></p>
     <div class="row">
-      <div class="col-lg-12 col-xl-2 d-grid gap-2">
+      <div class="col-lg-12 col-xl-4 d-grid gap-2">
         <%= button(gettext("Delete"), to: Routes.admin_brainstorming_path(@socket, :delete, @brainstorming.admin_url_id), method: :delete, class: "btn btn-danger") %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card mb-3">
+  <div class="card-header">
+    <h4><%= gettext("Edit Brainstorming Labels") %></h4>
+  </div>
+  <div class="card-body">
+    <%= f = form_for @changeset, "#", [phx_submit: :save, phx_change: :save] %>
+      <div class="row">
+        <div class="col">
+          <%= if Enum.empty?(f.data.labels) do %>
+            Empty list
+          <% else %>
+            <%= inputs_for f, :labels, fn p -> %>
+              <div class="input-group has-validation mb-3">
+                <%= color_input p, :color, class: "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}", title: gettext("Choose the label color") %>
+                <%= text_input p, :name, class: "form-control #{if p.errors[:name] || p.errors[:idea_idea_labels] || f.errors[:labels], do: "is-invalid"} #{if p.source.changes[:name] || p.source.changes[:color], do: "is-valid"}", placeholder: gettext("Type the label name"), phx_debounce: 500 %>
+                <button class="btn btn-outline-secondary" type="button" phx-click="remove_idea_label" value="<%= input_value(p, :id) %>"><%= gettext("Remove idea label") %></button>
+                <%= error_tag p, :color %>
+                <%= error_tag p, :name %>
+                <%= if message = p.errors[:idea_idea_labels] do %>
+                    <span class="is-invalid"></span>
+                    <span class="invalid-feedback" phx_feedback_for="<%= input_id(p, :name)%>"><%= translate_error(message) %></span>
+                <% end %>
+                <%= if message = f.errors[:labels] do %>
+                  <span class="invalid-feedback" phx_feedback_for="<%= input_id(f, :labels)%>"><%= translate_error(message) %></span>
+                <% end %>
+                <%= content_tag(:div, class: "valid-tooltip", phx_feedback_for: input_id(f, :labels)) do %>
+                  <%= gettext("Saved") %>
+                <% end %>
+              </div>
+            <% end %>
+            <%= error_tag f, :labels %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="row mb-3">
+        <div class="col-12 d-grid">
+          <button type="button" class="btn btn-secondary" phx-click="add_idea_label"><%= gettext("Add idea label") %></button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="card mb-3">
+  <div class="card-header">
+    <h4><%= gettext("Export") %></h4>
+  </div>
+  <div class="card-body">
+    <%= link gettext("Export to CSV"), to: Routes.admin_brainstorming_path(@socket, :export, @brainstorming.admin_url_id, _format: "csv"), class: "fw-bold"%><br />
+    <%= link gettext("Export to HTML"), to: Routes.admin_brainstorming_path(@socket, :export, @brainstorming.admin_url_id), class: "fw-bold" %>
+  </div>
+</div>
+
+<div class="card border-danger mb-3">
+  <div class="card-header">
+    <h4><%= gettext("Delete Brainstorming") %></h4>
+  </div>
+  <div class="card-body">
+    <div class="row mb-3">
+      <div class="col">
+        <p>
+          <%= gettext("Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone") %>
+        </p>
+        <%= button gettext("Delete"),
+          "data-confirm": gettext("Brainstorming delete are you sure"),
+          class: "btn btn-danger",
+          method: :delete,
+          to: Routes.admin_brainstorming_path(@socket, :delete, @brainstorming.admin_url_id)
+        %>
       </div>
     </div>
   </div>

--- a/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
+++ b/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
@@ -91,30 +91,26 @@
     <%= f = form_for @changeset, "#", [phx_submit: :save, phx_change: :save] %>
       <div class="row">
         <div class="col">
-          <%= if Enum.empty?(f.data.labels) do %>
-            Empty list
-          <% else %>
-            <%= inputs_for f, :labels, fn p -> %>
-              <div class="input-group has-validation mb-3 ">
-                <%= color_input p, :color, class: "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}", title: gettext("Choose the label color") %>
-                <%= text_input p, :name, class: "form-control #{if p.errors[:name] || p.errors[:idea_idea_labels] || f.errors[:labels], do: "is-invalid"} #{if p.source.changes[:name] || p.source.changes[:color], do: "is-valid"}", placeholder: gettext("Type the label name"), phx_debounce: 500 %>
-                <button class="btn btn-outline-secondary" type="button" phx-click="remove_idea_label" value="<%= input_value(p, :id) %>"><%= gettext("Remove idea label") %></button>
-                <%= error_tag_tooltip p, :color %>
-                <%= error_tag_tooltip p, :name %>
-                <%= if message = p.errors[:idea_idea_labels] do %>
-                    <span class="is-invalid"></span>
-                    <span class="invalid-tooltip" phx_feedback_for="<%= input_id(p, :name)%>"><%= translate_error(message) %></span>
-                <% end %>
-                <%= if message = f.errors[:labels] do %>
-                  <span class="invalid-tooltip" phx_feedback_for="<%= input_id(f, :labels)%>"><%= translate_error(message) %></span>
-                <% end %>
-                <%= content_tag(:span, class: "valid-tooltip", phx_feedback_for: input_id(f, :labels)) do %>
-                  <%= gettext("Saved") %>
-                <% end %>
-              </div>
-            <% end %>
-            <%= error_tag f, :labels %>
+          <%= inputs_for f, :labels, fn p -> %>
+            <div class="input-group has-validation mb-3 ">
+              <%= color_input p, :color, class: "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}", title: gettext("Choose the label color") %>
+              <%= text_input p, :name, class: "form-control #{if p.errors[:name] || p.errors[:idea_idea_labels] || f.errors[:labels], do: "is-invalid"} #{if p.source.changes[:name] || p.source.changes[:color], do: "is-valid"}", placeholder: gettext("Type the label name"), phx_debounce: 500 %>
+              <button class="btn btn-outline-secondary" type="button" phx-click="remove_idea_label" value="<%= input_value(p, :id) %>"><%= gettext("Remove idea label") %></button>
+              <%= error_tag_tooltip p, :color %>
+              <%= error_tag_tooltip p, :name %>
+              <%= if message = p.errors[:idea_idea_labels] do %>
+                  <span class="is-invalid"></span>
+                  <span class="invalid-tooltip" phx_feedback_for="<%= input_id(p, :name)%>"><%= translate_error(message) %></span>
+              <% end %>
+              <%= if message = f.errors[:labels] do %>
+                <span class="invalid-tooltip" phx_feedback_for="<%= input_id(f, :labels)%>"><%= translate_error(message) %></span>
+              <% end %>
+              <%= content_tag(:span, class: "valid-tooltip", phx_feedback_for: input_id(f, :labels)) do %>
+                <%= gettext("Saved") %>
+              <% end %>
+            </div>
           <% end %>
+          <%= error_tag_tooltip f, :labels %>
         </div>
       </div>
 

--- a/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
+++ b/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
@@ -1,9 +1,9 @@
 <div class="card mb-3">
-<div class="card-header">
-  <h4><%= gettext("Administration for brainstorming: %{name}", name: @brainstorming.name) %></h4>
-</div>
-<div class="card-body">
-  <p><%= gettext("Save this link to update / delete your brainstorming later on:") %></p>
+  <div class="card-header">
+    <h4><%= gettext("Administration for brainstorming: %{name}", name: @brainstorming.name) %></h4>
+  </div>
+  <div class="card-body">
+    <p><%= gettext("Save this link to update / delete your brainstorming later on:") %></p>
     <div class="input-group">
       <input
         aria-describedby="brainstorming-link-copy-to-clipboard-button"
@@ -40,10 +40,14 @@
     <%= link gettext("Proceed to your brainstorming"), to: Routes.brainstorming_show_path(@socket, :show, @brainstorming), class: "fw-bold" %>
     <br />
     <p>(<%= gettext("Brainstorming will be deleted ") %> <%= Timex.format!(brainstorming_available_until(@brainstorming), "{relative}", :relative) %>)</p>
+  </div>
+</div>
 
-    <h5><%= gettext("Edit Brainstorming") %></h5>
-    <hr />
-
+<div class="card mb-3">
+  <div class="card-header">
+    <h4><%= gettext("Edit Brainstorming") %></h4>
+  </div>
+  <div class="card-body">
     <%= f = form_for @changeset, "#", [phx_submit: :save, phx_change: :save] %>
       <div class="mb-3 position-relative">
         <%= label f, :name, class: "form-label" %>
@@ -53,11 +57,11 @@
           class: "valid-tooltip",
           phx_feedback_for: input_id(f, :name)
         ) do %>
-        <%= gettext("Saved") %>
+          <%= gettext("Saved") %>
         <% end %>
       </div>
 
-      <div class="form-check mb-3">
+      <div class="form-check mb-3 position-relative">
         <%= checkbox f, :option_show_link_to_settings, id: "checkbox-option-show-link-to-settings", class: "form-check-input #{if f.source.changes[:option_show_link_to_settings] != nil, do: "is-valid"}" %>
         <%= label f, :option_show_link_to_settings,
             gettext("Show brainstorming settings link for all users"),
@@ -75,59 +79,7 @@
           <%= gettext("Saved") %>
         <% end %>
       </div>
-
-      <h5><%= gettext("Edit Brainstorming Labels") %></h5>
-
-      <hr />
-
-      <div class="row">
-        <%= inputs_for f, :labels, fn p -> %>
-          <div class="input-group has-validation mb-3">
-            <%= color_input p, :color, class: "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}", title: gettext("Choose the label color") %>
-            <%= text_input p, :name, class: "form-control #{if p.errors[:name] || p.errors[:idea_idea_labels] || f.errors[:labels], do: "is-invalid"} #{if p.source.changes[:name] || p.source.changes[:color], do: "is-valid"}", placeholder: gettext("Type the label name"), phx_debounce: 500 %>
-            <button class="btn btn-outline-secondary" type="button" phx-click="remove_idea_label" value="<%= input_value(p, :id) %>"><%= gettext("Remove idea label") %></button>
-            <%= error_tag p, :color %>
-            <%= error_tag p, :name %>
-            <%= if message = p.errors[:idea_idea_labels] do %>
-                <span class="is-invalid"></span>
-                <span class="invalid-feedback" phx_feedback_for="<%= input_id(p, :name)%>"><%= translate_error(message) %></span>
-            <% end %>
-            <%= if message = f.errors[:labels] do %>
-              <span class="invalid-feedback" phx_feedback_for="<%= input_id(f, :labels)%>"><%= translate_error(message) %></span>
-            <% end %>
-            <%= content_tag(:div, class: "valid-tooltip", phx_feedback_for: input_id(f, :labels)) do %>
-              <%= gettext("Saved") %>
-            <% end %>
-          </div>
-        <% end %>
-        <%= error_tag f, :labels %>
-      </div>
-
-      <div class="row mb-3">
-        <div class="col-12 d-grid">
-          <button type="button" class="btn btn-secondary" phx-click="add_idea_label"><%= gettext("Add idea label") %></button>
-        </div>
-      </div>
-
     </form>
-
-    <br /><br />
-
-    <br />
-    <h5><%= gettext("Export") %></h5>
-    <hr />
-    <%= link gettext("Export to CSV"), to: Routes.admin_brainstorming_path(@socket, :export, @brainstorming.admin_url_id, _format: "csv"), class: "fw-bold"%><br />
-    <%= link gettext("Export to HTML"), to: Routes.admin_brainstorming_path(@socket, :export, @brainstorming.admin_url_id), class: "fw-bold" %>
-    <br /><br />
-
-    <h5><%= gettext("Delete Brainstorming") %></h5>
-    <hr />
-    <p><%= gettext("Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone") %></p>
-    <div class="row">
-      <div class="col-lg-12 col-xl-4 d-grid gap-2">
-        <%= button(gettext("Delete"), to: Routes.admin_brainstorming_path(@socket, :delete, @brainstorming.admin_url_id), method: :delete, class: "btn btn-danger") %>
-      </div>
-    </div>
   </div>
 </div>
 
@@ -143,7 +95,7 @@
             Empty list
           <% else %>
             <%= inputs_for f, :labels, fn p -> %>
-              <div class="input-group has-validation mb-3">
+              <div class="input-group has-validation mb-3 ">
                 <%= color_input p, :color, class: "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}", title: gettext("Choose the label color") %>
                 <%= text_input p, :name, class: "form-control #{if p.errors[:name] || p.errors[:idea_idea_labels] || f.errors[:labels], do: "is-invalid"} #{if p.source.changes[:name] || p.source.changes[:color], do: "is-valid"}", placeholder: gettext("Type the label name"), phx_debounce: 500 %>
                 <button class="btn btn-outline-secondary" type="button" phx-click="remove_idea_label" value="<%= input_value(p, :id) %>"><%= gettext("Remove idea label") %></button>

--- a/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
+++ b/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex
@@ -52,7 +52,7 @@
       <div class="mb-3 position-relative">
         <%= label f, :name, class: "form-label" %>
         <%= text_input f, :name, class: "form-control #{if f.errors[:name], do: "is-invalid"} #{if f.source.changes[:name], do: "is-valid"}", phx_debounce: 500, phx_feedback_for: input_id(f, :name) %>
-        <%= error_tag f, :name %>
+        <%= error_tag_tooltip f, :name %>
         <%= content_tag(:div,
           class: "valid-tooltip",
           phx_feedback_for: input_id(f, :name)
@@ -99,16 +99,16 @@
                 <%= color_input p, :color, class: "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}", title: gettext("Choose the label color") %>
                 <%= text_input p, :name, class: "form-control #{if p.errors[:name] || p.errors[:idea_idea_labels] || f.errors[:labels], do: "is-invalid"} #{if p.source.changes[:name] || p.source.changes[:color], do: "is-valid"}", placeholder: gettext("Type the label name"), phx_debounce: 500 %>
                 <button class="btn btn-outline-secondary" type="button" phx-click="remove_idea_label" value="<%= input_value(p, :id) %>"><%= gettext("Remove idea label") %></button>
-                <%= error_tag p, :color %>
-                <%= error_tag p, :name %>
+                <%= error_tag_tooltip p, :color %>
+                <%= error_tag_tooltip p, :name %>
                 <%= if message = p.errors[:idea_idea_labels] do %>
                     <span class="is-invalid"></span>
-                    <span class="invalid-feedback" phx_feedback_for="<%= input_id(p, :name)%>"><%= translate_error(message) %></span>
+                    <span class="invalid-tooltip" phx_feedback_for="<%= input_id(p, :name)%>"><%= translate_error(message) %></span>
                 <% end %>
                 <%= if message = f.errors[:labels] do %>
-                  <span class="invalid-feedback" phx_feedback_for="<%= input_id(f, :labels)%>"><%= translate_error(message) %></span>
+                  <span class="invalid-tooltip" phx_feedback_for="<%= input_id(f, :labels)%>"><%= translate_error(message) %></span>
                 <% end %>
-                <%= content_tag(:div, class: "valid-tooltip", phx_feedback_for: input_id(f, :labels)) do %>
+                <%= content_tag(:span, class: "valid-tooltip", phx_feedback_for: input_id(f, :labels)) do %>
                   <%= gettext("Saved") %>
                 <% end %>
               </div>

--- a/lib/mindwendel_web/views/error_helpers.ex
+++ b/lib/mindwendel_web/views/error_helpers.ex
@@ -9,11 +9,19 @@ defmodule MindwendelWeb.ErrorHelpers do
   Generates tag for inlined form input errors.
   """
   def error_tag(form, field) do
+    error_tag(form, field, error_tag_css_class: "invalid-feedback")
+  end
+
+  def error_tag_tooltip(form, field) do
+    error_tag(form, field, error_tag_css_class: "invalid-tooltip")
+  end
+
+  def error_tag(form, field, error_tag_css_class: error_tag_css_class) do
     form.errors
     |> Keyword.get_values(field)
     |> Enum.map(fn error ->
       content_tag(:span, translate_error(error),
-        class: "invalid-feedback",
+        class: error_tag_css_class,
         phx_feedback_for: input_id(form, field)
       )
     end)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -42,7 +42,7 @@ msgid "Are you sure you want to delete this idea?"
 msgstr "Möchtest du die Idee löschen?"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:95
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:144
 msgid "Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone"
 msgstr "Achtung: Hiermit löschst du das Brainstorming und alle dazugehörigen Ideen. Diese Aktion kann nicht rückgängig gemacht werden."
 
@@ -52,7 +52,8 @@ msgid "Close"
 msgstr "Schließen"
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:18
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:24
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:20
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -67,22 +68,22 @@ msgid "Create!"
 msgstr "Erstellen!"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:98
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:146
 msgid "Delete"
 msgstr "Löschen"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:93
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:138
 msgid "Delete Brainstorming"
 msgstr "Lösche Brainstorming"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:89
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:131
 msgid "Export to CSV"
 msgstr "Export als CSV"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:90
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:132
 msgid "Export to HTML"
 msgstr "Export als HTML"
 
@@ -128,7 +129,7 @@ msgid "Open new idea page (Hotkey: i)"
 msgstr "Öffne neue Ideen Dialog (Hotkey: i)"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:10
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:40
 msgid "Proceed to your brainstorming"
 msgstr "Weiter zu deinem Brainstorming"
 
@@ -190,12 +191,12 @@ msgid "Your brainstorming was created successfully! Share the link with other pe
 msgstr "Dein Brainstorming wurde erstellt! Teile den Link mit anderen Personen und legt los."
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:14
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:48
 msgid "Edit Brainstorming"
 msgstr "Editiere Brainstorming"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:87
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:128
 msgid "Export"
 msgstr "Export"
 
@@ -230,17 +231,17 @@ msgid "Administration for brainstorming: %{name}"
 msgstr "Administration für: %{name}"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:33
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:67
 msgid "Show brainstorming settings link for all users"
 msgstr "Zeige Link zur Administration für alle Nutzer"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:39
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:73
 msgid "Warning: Please make sure you save the admin link at the top, before hiding the settings link!"
 msgstr "Achtung: Bitte speichere den Admin-Link oben ab, bevor du den Link zur Administration versteckst."
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:12
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:42
 msgid "Brainstorming will be deleted "
 msgstr "Brainstorming wird gelöscht in "
 
@@ -250,17 +251,17 @@ msgid "Brainstormings will be deleted after %{days} days."
 msgstr "Brainstormings werden nach %{days} Tagen gelöscht."
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:56
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:96
 msgid "Choose the label color"
 msgstr "Wähle die Farbe für das Label aus"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:49
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:88
 msgid "Edit Brainstorming Labels"
 msgstr "Editiere Brainstorming Labels"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:57
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:97
 msgid "Type the label name"
 msgstr "Gebe dem Label einen Namen"
 
@@ -290,18 +291,18 @@ msgid "yellow"
 msgstr "Gelb"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:78
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:119
 msgid "Add idea label"
 msgstr "Neues Label"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:58
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:98
 msgid "Remove idea label"
 msgstr "Löschen"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:26
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:45 lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:69
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:60
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:79 lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:109
 msgid "Saved"
 msgstr "Gespeichert"
 
@@ -312,12 +313,14 @@ msgid "Your brainstorming was not saved."
 msgstr "Dein Brainstorming wurde nicht gespeichert."
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:22
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:29
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:24
 msgid "Join my brainstorming"
 msgstr "Trete meinem Brainstorming bei."
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:23
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:30
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:25
 msgid "Mindwendel Brainstorming"
 msgstr "Mindwendel Brainstorming"
 
@@ -332,12 +335,17 @@ msgstr "Teilen"
 msgid "Share brainstorming"
 msgstr "Teile Dein Brainstorming"
 
-#, elixir-format, fuzzy
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:67
+#, elixir-format
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:70
 msgid "Download as png"
 msgstr "Download als PNG"
 
-#, elixir-format, fuzzy
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:56
+#, elixir-format
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:58
 msgid "Download as svg"
 msgstr "Download als SVG"
+
+#, elixir-format, fuzzy
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:147
+msgid "Brainstorming delete are you sure"
+msgstr "Bist du sicher, dass das Brainstorming gelöscht werden soll?"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -41,7 +41,7 @@ msgid "Are you sure you want to delete this idea?"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:95
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:144
 msgid "Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone"
 msgstr ""
 
@@ -51,7 +51,8 @@ msgid "Close"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:18
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:24
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:20
 msgid "Copy"
 msgstr ""
 
@@ -66,22 +67,22 @@ msgid "Create!"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:98
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:146
 msgid "Delete"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:93
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:138
 msgid "Delete Brainstorming"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:89
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:131
 msgid "Export to CSV"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:90
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:132
 msgid "Export to HTML"
 msgstr ""
 
@@ -127,7 +128,7 @@ msgid "Open new idea page (Hotkey: i)"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:10
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:40
 msgid "Proceed to your brainstorming"
 msgstr ""
 
@@ -189,12 +190,12 @@ msgid "Your brainstorming was created successfully! Share the link with other pe
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:14
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:48
 msgid "Edit Brainstorming"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:87
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:128
 msgid "Export"
 msgstr ""
 
@@ -229,17 +230,17 @@ msgid "Administration for brainstorming: %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:33
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:67
 msgid "Show brainstorming settings link for all users"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:39
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:73
 msgid "Warning: Please make sure you save the admin link at the top, before hiding the settings link!"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:12
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:42
 msgid "Brainstorming will be deleted "
 msgstr ""
 
@@ -249,17 +250,17 @@ msgid "Brainstormings will be deleted after %{days} days."
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:56
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:96
 msgid "Choose the label color"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:49
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:88
 msgid "Edit Brainstorming Labels"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:57
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:97
 msgid "Type the label name"
 msgstr ""
 
@@ -289,18 +290,18 @@ msgid "yellow"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:78
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:119
 msgid "Add idea label"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:58
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:98
 msgid "Remove idea label"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:26
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:45 lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:69
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:60
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:79 lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:109
 msgid "Saved"
 msgstr ""
 
@@ -311,12 +312,14 @@ msgid "Your brainstorming was not saved."
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:22
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:29
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:24
 msgid "Join my brainstorming"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:23
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:30
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:25
 msgid "Mindwendel Brainstorming"
 msgstr ""
 
@@ -332,11 +335,16 @@ msgid "Share brainstorming"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:67
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:70
 msgid "Download as png"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:56
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:58
 msgid "Download as svg"
+msgstr ""
+
+#, elixir-format
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:147
+msgid "Brainstorming delete are you sure"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -42,7 +42,7 @@ msgid "Are you sure you want to delete this idea?"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:95
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:144
 msgid "Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone"
 msgstr ""
 
@@ -52,7 +52,8 @@ msgid "Close"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:18
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:24
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:20
 msgid "Copy"
 msgstr ""
 
@@ -67,22 +68,22 @@ msgid "Create!"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:98
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:146
 msgid "Delete"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:93
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:138
 msgid "Delete Brainstorming"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:89
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:131
 msgid "Export to CSV"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:90
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:132
 msgid "Export to HTML"
 msgstr ""
 
@@ -128,7 +129,7 @@ msgid "Open new idea page (Hotkey: i)"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:10
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:40
 msgid "Proceed to your brainstorming"
 msgstr ""
 
@@ -190,12 +191,12 @@ msgid "Your brainstorming was created successfully! Share the link with other pe
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:14
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:48
 msgid "Edit Brainstorming"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:87
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:128
 msgid "Export"
 msgstr ""
 
@@ -230,17 +231,17 @@ msgid "Administration for brainstorming: %{name}"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:33
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:67
 msgid "Show brainstorming settings link for all users"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:39
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:73
 msgid "Warning: Please make sure you save the admin link at the top, before hiding the settings link!"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:12
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:42
 msgid "Brainstorming will be deleted "
 msgstr ""
 
@@ -250,17 +251,17 @@ msgid "Brainstormings will be deleted after %{days} days."
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:56
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:96
 msgid "Choose the label color"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:49
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:88
 msgid "Edit Brainstorming Labels"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:57
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:97
 msgid "Type the label name"
 msgstr ""
 
@@ -290,18 +291,18 @@ msgid "yellow"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:78
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:119
 msgid "Add idea label"
 msgstr ""
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:58
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:98
 msgid "Remove idea label"
 msgstr "Remove"
 
 #, elixir-format
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:26
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:45 lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:69
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:60
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:79 lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:109
 msgid "Saved"
 msgstr "Saved"
 
@@ -312,12 +313,14 @@ msgid "Your brainstorming was not saved."
 msgstr "Your brainstorming was not saved."
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:22
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:29
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:24
 msgid "Join my brainstorming"
 msgstr "Join my brainstorming"
 
 #, elixir-format
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:23
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:30
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:25
 msgid "Mindwendel Brainstorming"
 msgstr "Mindwendel Brainstorming"
 
@@ -332,12 +335,17 @@ msgstr "Share"
 msgid "Share brainstorming"
 msgstr "Share brainstorming"
 
-#, elixir-format, fuzzy
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:67
+#, elixir-format
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:70
 msgid "Download as png"
 msgstr "Download as png"
 
-#, elixir-format, fuzzy
-#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:56
+#, elixir-format
+#: lib/mindwendel_web/live/brainstorming_live/share_component.html.leex:58
 msgid "Download as svg"
 msgstr "Download as svg"
+
+#, elixir-format, fuzzy
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.leex:147
+msgid "Brainstorming delete are you sure"
+msgstr "Are you sure that you want to delete this brainstorming?"

--- a/test/mindwendel_web/live/admin/brainstorming_live/edit_test.exs
+++ b/test/mindwendel_web/live/admin/brainstorming_live/edit_test.exs
@@ -26,7 +26,7 @@ defmodule MindwendelWeb.Admin.BrainstormingLive.EditTest do
       live(conn, Routes.admin_brainstorming_edit_path(conn, :edit, brainstorming.admin_url_id))
 
     assert edit_live_view
-           |> element("form")
+           |> element("form#form-edit-brainstorming")
            |> render_submit(%{
              brainstorming: %{name: "New brainstorming name"}
            }) =~
@@ -114,7 +114,7 @@ defmodule MindwendelWeb.Admin.BrainstormingLive.EditTest do
 
     # It should still be there because the idea label is still connected iwth an idea and therefore cannot be deleted.
     assert edit_live_view
-           |> element(".invalid-feedback", "This label is associated with an idea")
+           |> element(".invalid-tooltip", "This label is associated with an idea")
            |> has_element?()
 
     assert edit_live_view


### PR DESCRIPTION
## Further Notes

## Results

### Before
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/592424/189767517-ee6777f2-43dc-48aa-b61f-baac0a150a5e.png">

### After
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/592424/189767425-083fc293-6419-4f80-ac48-befd58c24cd6.png">

## Checklist

- [x] Adding sharing dialog to admin page
- [x] Add Copy to clipboard button to url input
- [x] Made input with brainstorming url readonly
- [x] Gracefully handle cancel sharing dialog on iOS and Safari
- [x] Improve quality of code, see https://github.com/mindwendel/mindwendel/pull/129/files#diff-2126216ecd2ff9ae9b5f0c1e84d8fecb4ee4e54dc21685f69a590c2162dec186R68
- [x] Add translation 
- [x] Reorganize edit view with standard bootstrap components
- [x] Fix layout bug regarding wrong positioning of validation-tooltip
- [x] Extracted ShareComponent for QrCode and Native Sharing capability