### PR TITLE
Fix broken Dockerfile dev and prod stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 ARG ALPINE_VERSION=3.13
 
 FROM elixir:1.11-alpine as elixir_alpine
@@ -7,8 +6,12 @@ ENV APP_PATH=/app
 
 RUN apk add \
     --update-cache \
-    nodejs \
-    npm
+    --no-cache \
+    --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ \
+    # Version taken from https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.11
+    nodejs=12.22.6-r0 \
+    # Version taken from https://pkgs.alpinelinux.org/packages?name=npm&branch=v3.11
+    npm=12.22.6-r0
 
 RUN mix do local.hex --force, local.rebar --force
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
-ARG ALPINE_VERSION=3.13
+# IMPORTANT NOTE: To avoid compliation and runtime errors, this ALPINE_VERSION needs to match the alpine version of the stage `production_build`.
+# As the the stage `production_build` uses the docker image `elixir:1.11-alpine` as base image it is not clear which alpine version is used here.
+# Unfortunately, the maintainers of docker image do not provide the possibility to pin the alpine version of the image.
+# However, they also change the underlying alpine version from time to time. This can cause compilation and runtime errors,
+# e.g. https://stackoverflow.com/questions/72609505/issue-with-building-elixir-and-beam-on-alpine-linux .
+# 
+# This means, if a compliation and runtime error occur, we need to look up the alpine version directly in the codebase and match it by hand: 
+# - https://github.com/erlef/docker-elixir/blob/master/1.11/alpine/Dockerfile
+# - https://github.com/erlang/docker-erlang-otp/blob/master/23/alpine/Dockerfile
+ARG ALPINE_VERSION=3.16
 
 FROM elixir:1.11-alpine as elixir_alpine
 
 ENV APP_PATH=/app
 
-RUN apk add \
-    --update-cache \
-    --no-cache \
-    --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ \
-    # Version taken from https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.11
-    nodejs=12.22.6-r0 \
-    # Version taken from https://pkgs.alpinelinux.org/packages?name=npm&branch=v3.11
-    npm=12.22.6-r0
+RUN set -eux ; \
+    apk add \
+      --update-cache \
+      --no-cache \
+      --repository http://dl-cdn.alpinelinux.org/alpine/v3.11/main/ \
+      # Version taken from https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.11
+      nodejs=12.22.6-r0 \
+      # Version taken from https://pkgs.alpinelinux.org/packages?name=npm&branch=v3.11
+      npm=12.22.6-r0
 
 RUN mix do local.hex --force, local.rebar --force
 
@@ -19,10 +29,11 @@ WORKDIR $APP_PATH
 
 FROM elixir_alpine as development
 
-RUN apk add \
-    # The package `inotify-tools` is needed for instant live-reload of the the phoenix server
-    inotify-tools \
-    postgresql-client
+RUN set -eux ; \
+    apk add \
+      # The package `inotify-tools` is needed for instant live-reload of the the phoenix server
+      inotify-tools \
+      postgresql-client
 
 # Install mix dependencies
 COPY mix.exs mix.lock $APP_PATH/
@@ -46,7 +57,7 @@ RUN mix do deps.get, deps.compile
 
 # Build assets
 COPY assets $APP_PATH/assets/
-RUN set -eux; \
+RUN set -eux ; \
     npm \
       --loglevel=error \
       --no-audit \


### PR DESCRIPTION
## Further Notes

- The underlying alpine version of the base image `elixir:1.11-alpine` was updated in the last months => from `alpine-3.13` to  `alpine-3.16`; this had the following side effects:
  - `nodejs` and `npm` updated as well from `v12` to `v16` because `apk add nodejs` installs the latest version from the package manager => solved this by pinning the version
  - Docker stage `production_build` and and `production` used different versions and this caused a problem on runtime

## Results

## Checklist
- [x] Pinning the version of `nodejs` and `npm`
- [x] Adjusted the alpine version to use the same alpine version on all stages