### PR TITLE
Link preview thumbnail images are not loaded because of wrong csp directive

### DIFF
--- a/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
+++ b/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
@@ -17,7 +17,7 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
 
   def content_security_policy_directives() do
     [
-      "default-src 'none' ; ",
+      "default-src 'none' ;",
 
       # Usually, the csp directive `connect-src 'self'` is enough,
       # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src .
@@ -25,7 +25,7 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
       # However, the `connect-src 'self'` does not resolve to websocket schemes in all browsers, e.g. Safari,
       # see https://github.com/w3c/webappsec-csp/issues/7 .
       #
-      # Therefore, we need to explicitly add the allowed websocket uris here so that live views will work in safari in combination with CSP policies.
+      # Therefore, we need to explicitly add the allowed websocket uris here so that live views will work in Safari in combination with CSP policies.
       # e.g. `connect-src ws://localhost:*` or `connect-src wss://#{@host}` .
       "connect-src 'self' #{
         %URI{
@@ -33,14 +33,14 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
           host: get_host(),
           port: get_port()
         }
-      } ; ",
-      "font-src    'self' ; ",
-      "frame-src   'self' ; ",
+      } ;",
+      "font-src    'self' ;",
+      "frame-src   'self' ;",
 
       # We add csp sources http: and https: to allow the browser to load the link preview image extracted from the idea body
-      "img-src     'self' data: https: http: ; ",
-      "script-src  'self' 'unsafe-eval' ; ",
-      "style-src   'self' 'unsafe-inline' ; "
+      "img-src     'self' data: https: http: ;",
+      "script-src  'self' 'unsafe-eval' ;",
+      "style-src   'self' 'unsafe-inline' ;"
     ]
     |> Enum.join(" ")
   end

--- a/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
+++ b/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
@@ -27,13 +27,7 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
       #
       # Therefore, we need to explicitly add the allowed websocket uris here so that live views will work in Safari in combination with CSP policies.
       # e.g. `connect-src ws://localhost:*` or `connect-src wss://#{@host}` .
-      "connect-src 'self' #{
-        %URI{
-          scheme: get_websocket_scheme(),
-          host: get_host(),
-          port: get_port()
-        }
-      } ;",
+      "connect-src 'self' #{%URI{scheme: get_websocket_scheme(), host: get_host(), port: get_port()}} ;",
       "font-src    'self' ;",
       "frame-src   'self' ;",
 

--- a/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
+++ b/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
@@ -16,21 +16,33 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
   end
 
   def content_security_policy_directives() do
-    # Usually, the csp directive `connect-src 'self'` is enough,
-    # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src .
-    #
-    # However, the `connect-src 'self'` does not resolve to websocket schemes in all browsers, e.g. Safari,
-    # see https://github.com/w3c/webappsec-csp/issues/7 .
-    #
-    # Therefore, we need to explicitly add the allowed websocket uris here so that live views will work in safari in combination with CSP policies.
-    # e.g. `connect-src ws://localhost:*` or `connect-src wss://#{@host}` .
-    "default-src 'none' ; " <>
-      "connect-src 'self' #{%URI{scheme: get_websocket_scheme(), host: get_host(), port: get_port()}} ; " <>
-      "font-src    'self' ; " <>
-      "frame-src   'self' ; " <>
-      "img-src     'self' data: ; " <>
-      "script-src  'self' 'unsafe-eval' ; " <>
+    [
+      "default-src 'none' ; ",
+
+      # Usually, the csp directive `connect-src 'self'` is enough,
+      # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src .
+      #
+      # However, the `connect-src 'self'` does not resolve to websocket schemes in all browsers, e.g. Safari,
+      # see https://github.com/w3c/webappsec-csp/issues/7 .
+      #
+      # Therefore, we need to explicitly add the allowed websocket uris here so that live views will work in safari in combination with CSP policies.
+      # e.g. `connect-src ws://localhost:*` or `connect-src wss://#{@host}` .
+      "connect-src 'self' #{
+        %URI{
+          scheme: get_websocket_scheme(),
+          host: get_host(),
+          port: get_port()
+        }
+      } ; ",
+      "font-src    'self' ; ",
+      "frame-src   'self' ; ",
+
+      # We add csp sources http: and https: to allow the browser to load the link preview image extracted from the idea body
+      "img-src     'self' data: https: http: ; ",
+      "script-src  'self' 'unsafe-eval' ; ",
       "style-src   'self' 'unsafe-inline' ; "
+    ]
+    |> Enum.join(" ")
   end
 
   def get_host() do

--- a/test/mindwendel_web/live/response_header_content_security_policy_test.exs
+++ b/test/mindwendel_web/live/response_header_content_security_policy_test.exs
@@ -1,0 +1,63 @@
+defmodule MindwendelWeb.ResponseHeaderContentSecurityPolicyTest do
+  use MindwendelWeb.ConnCase
+
+  alias Mindwendel.Factory
+
+  setup do
+    %{
+      brainstorming: Factory.insert!(:brainstorming)
+    }
+  end
+
+  describe "csp directive 'default-src'" do
+    test "allows nothing by default for security reasons", %{
+      conn: conn,
+      brainstorming: brainstorming
+    } do
+      conn_response = get(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+      assert conn_response
+             |> get_resp_header("content-security-policy")
+             |> List.first() =~ ~r/(default-src)\s+('none') ;/
+    end
+  end
+
+  describe "csp directive 'connect-src'" do
+    test "allows websocket connection only to itself", %{
+      conn: conn,
+      brainstorming: brainstorming
+    } do
+      conn_response = get(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+      assert conn_response
+             |> get_resp_header("content-security-policy")
+             |> List.first() =~ ~r/(connect-src)\s+('self')/
+    end
+
+    test "allows websocket connection to specific websocket endpoint (defined in test environment) to support live views and in all browsers",
+         %{
+           conn: conn,
+           brainstorming: brainstorming
+         } do
+      conn_response = get(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+      assert conn_response
+             |> get_resp_header("content-security-policy")
+             |> List.first() =~ ~r/(connect-src)\s+'self' (wss:\/\/localhost) ;/
+    end
+  end
+
+  describe "csp directive 'img-src'" do
+    test "allows image resources via 'http' and 'https' and from anywhere to support preview link image feature",
+         %{
+           conn: conn,
+           brainstorming: brainstorming
+         } do
+      conn_response = get(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+      assert conn_response
+             |> get_resp_header("content-security-policy")
+             |> List.first() =~ ~r/(img-src)\s+('self' data: https: http:) ;/
+    end
+  end
+end


### PR DESCRIPTION
## Further Notes

## New Feature / Enhancement

The following shows how it should look like.

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/592424/195927072-3aa02af0-86a8-4137-8123-0938cadb6227.png">

Currently, the preview thumbnail images are not shown, see https://www.mindwendel.com/brainstormings/7c0929f4-7032-456a-b162-cd5e62502441 .

## Checklist

- [x] Fix csp directives to allow images through `http` and `https`
- [x] Add test to ensure that preview link images can be loaded