### PR TITLE
Update github action steps to latest version that also runs on node v16

### DIFF
--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -25,17 +25,13 @@ jobs:
       - uses: actions/cache@v3
         id: cache
         with:
-          path: |
-            _build
-            deps
+          path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
-      # install hex:
-      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix do local.hex --force, local.rebar --force
       - run: mix deps.get
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: mix compile
 
   check_mix_test:
     # Containers must run in Linux based operating systems
@@ -79,14 +75,11 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: |
-            _build
-            deps
+          path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
-      # install hex:
-      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix do local.hex --force, local.rebar --force
       - run: mix compile
       - run: mix ecto.create
       - run: mix ecto.migrate
@@ -104,14 +97,12 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: |
-            _build
-            deps
+          path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
-      # install hex:
-      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix do local.hex --force, local.rebar --force
+      
       - run: mix format --check-formatted
   
   check_mix_gettext_extract_up_to_date:
@@ -130,8 +121,8 @@ jobs:
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
-      # install hex:
-      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix do local.hex --force, local.rebar --force
+      - run: mix compile
       - run: mix gettext.extract --check-up-to-date
 
   check_mix_sobelow:
@@ -146,12 +137,10 @@ jobs:
         
       - uses: actions/cache@v3
         with:
-          path: |
-            _build
-            deps
+          path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
-      # install hex:
-      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix do local.hex --force, local.rebar --force
+      - run: mix compile
       - run: mix sobelow --config

--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -36,7 +36,6 @@ jobs:
       - run: mix deps.get
         if: steps.cache.outputs.cache-hit != 'true'
       - run: mix compile
-        if: steps.cache.outputs.cache-hit != 'true'
 
   check_mix_test:
     # Containers must run in Linux based operating systems

--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -39,13 +39,17 @@ jobs:
       - uses: actions/cache@v3
         id: cache
         with:
-          path: deps
+          path: |
+            _build
+            deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
       # install hex:
       - run: mix local.hex --force && mix local.rebar --force
       - run: mix deps.get
+        if: steps.cache.outputs.cache-hit != 'true'
+      - run: mix compile
         if: steps.cache.outputs.cache-hit != 'true'
 
   check_mix_test:
@@ -90,7 +94,9 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: deps
+          path: |
+            _build
+            deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
@@ -113,7 +119,9 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: deps
+          path: |
+            _build
+            deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       
@@ -153,7 +161,9 @@ jobs:
         
       - uses: actions/cache@v3
         with:
-          path: deps
+          path: |
+            _build
+            deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-v4
       

--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -10,6 +10,20 @@ on:
     branches: [master]
 
 jobs:
+  pre_build_mix_format:
+    runs-on: ubuntu-latest
+    container: hexpm/elixir:1.13.1-erlang-24.2-debian-bullseye-20210902-slim
+
+    needs: build_deps
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      # Install hex:
+      - run: mix local.hex --force && mix local.rebar --force
+      - run: mix format --check-formatted
+
   build_deps:
     runs-on: ubuntu-latest
     # Currently, this need to be synced manually with the Dockerfile. In the future, the workflow should be changed,
@@ -19,10 +33,10 @@ jobs:
 
     steps:
       # See https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # See https://github.com/actions/checkout
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: deps
@@ -72,9 +86,9 @@ jobs:
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
@@ -95,9 +109,9 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
@@ -115,9 +129,9 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}
@@ -135,9 +149,9 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-v4-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -10,20 +10,6 @@ on:
     branches: [master]
 
 jobs:
-  pre_build_mix_format:
-    runs-on: ubuntu-latest
-    container: hexpm/elixir:1.13.1-erlang-24.2-debian-bullseye-20210902-slim
-
-    needs: build_deps
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-
-      # Install hex:
-      - run: mix local.hex --force && mix local.rebar --force
-      - run: mix format --check-formatted
-
   build_deps:
     runs-on: ubuntu-latest
     # Currently, this need to be synced manually with the Dockerfile. In the future, the workflow should be changed,


### PR DESCRIPTION
## Further Notes

- Current pipeline configuration contain warnings regarding steps with an older node version, see https://github.com/mindwendel/mindwendel/actions/runs/3604335613

## New Features / Enhancements

- [x] Updated pipeline steps to latest node version to avoid warnings, see fixed pipeline without warnings https://github.com/mindwendel/mindwendel/actions/runs/3604403750

## After Merge Checklist

