### PR TITLE
Handle empty env var DATABASE_URL in startup script

### DIFF
--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -2,7 +2,7 @@
 cd -P -- "$(dirname -- "$0")"
 
 # Only continue if database is ready
-while ! pg_isready -q -d $DATABASE_URL -h $DATABASE_HOST -p $DATABASE_PORT -U $DATABASE_USER
+while ! pg_isready -q -d ${DATABASE_URL:-""} -h $DATABASE_HOST -p $DATABASE_PORT -U $DATABASE_USER
 do
   echo "Waiting for database (host: $DATABASE_HOST, port: $DATABASE_PORT, database_user: $DATABASE_USER"
   sleep 2


### PR DESCRIPTION
## Further Notes

- For deployment of mindwendel, we want to allow two options for definoin we allow di
- 

## New Features / Enhancements

- [x] Handling missing env var DATABASE_URL during startup and deployment

## After Merge Checklist
