### PR TITLE
Allow brainstorming moderator to delete ideas of anyone

### DIFF
--- a/lib/mindwendel/accounts/user.ex
+++ b/lib/mindwendel/accounts/user.ex
@@ -5,15 +5,15 @@ defmodule Mindwendel.Accounts.User do
 
   alias Mindwendel.Brainstormings.Brainstorming
   alias Mindwendel.Brainstormings.Idea
-  alias Mindwendel.Brainstormings.BrainstormingAdminUser
+  alias Mindwendel.Brainstormings.BrainstormingModeratingUser
   alias Mindwendel.Accounts.BrainstormingUser
 
   schema "users" do
     field :username, :string, default: "Anonymous"
     many_to_many :brainstormings, Brainstorming, join_through: BrainstormingUser
 
-    many_to_many :administrable_brainstormings, Brainstorming,
-      join_through: BrainstormingAdminUser
+    many_to_many :moderated_brainstormings, Brainstorming,
+      join_through: BrainstormingModeratingUser
 
     has_many :ideas, Idea
 

--- a/lib/mindwendel/accounts/user.ex
+++ b/lib/mindwendel/accounts/user.ex
@@ -5,11 +5,16 @@ defmodule Mindwendel.Accounts.User do
 
   alias Mindwendel.Brainstormings.Brainstorming
   alias Mindwendel.Brainstormings.Idea
+  alias Mindwendel.Brainstormings.BrainstormingAdminUser
   alias Mindwendel.Accounts.BrainstormingUser
 
   schema "users" do
     field :username, :string, default: "Anonymous"
     many_to_many :brainstormings, Brainstorming, join_through: BrainstormingUser
+
+    many_to_many :administrable_brainstormings, Brainstorming,
+      join_through: BrainstormingAdminUser
+
     has_many :ideas, Idea
 
     timestamps()

--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -34,8 +34,8 @@ defmodule Mindwendel.Brainstormings do
   end
 
   def add_moderating_user(%Brainstorming{} = brainstorming, %User{} = user) do
-    %BrainstormingModeratingUser{user_id: user.id, brainstorming_id: brainstorming.id}
-    |> Ecto.Changeset.change()
+    %BrainstormingModeratingUser{brainstorming_id: brainstorming.id, user_id: user.id}
+    |> BrainstormingModeratingUser.changeset()
     |> Repo.insert()
   end
 

--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -7,9 +7,11 @@ defmodule Mindwendel.Brainstormings do
   alias Mindwendel.Repo
 
   alias Mindwendel.Brainstormings.Idea
+  alias Mindwendel.Accounts.User
   alias Mindwendel.Brainstormings.IdeaLabel
   alias Mindwendel.Brainstormings.IdeaIdeaLabel
   alias Mindwendel.Brainstormings.Brainstorming
+  alias Mindwendel.Brainstormings.BrainstormingAdminUser
   alias Mindwendel.Brainstormings.Like
 
   @doc """
@@ -29,6 +31,12 @@ defmodule Mindwendel.Brainstormings do
         order_by: [desc: brainstorming.inserted_at],
         limit: ^limit
     )
+  end
+
+  def add_admin_user(%Brainstorming{} = brainstorming, %User{} = user) do
+    %BrainstormingAdminUser{user_id: user.id, brainstorming_id: brainstorming.id}
+    |> Ecto.Changeset.change()
+    |> Repo.insert()
   end
 
   @doc """
@@ -280,6 +288,7 @@ defmodule Mindwendel.Brainstormings do
     Repo.get!(Brainstorming, id)
     |> Repo.preload([
       :users,
+      :admin_users,
       labels: from(idea_label in IdeaLabel, order_by: idea_label.position_order),
       ideas: [
         :link,

--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -11,7 +11,7 @@ defmodule Mindwendel.Brainstormings do
   alias Mindwendel.Brainstormings.IdeaLabel
   alias Mindwendel.Brainstormings.IdeaIdeaLabel
   alias Mindwendel.Brainstormings.Brainstorming
-  alias Mindwendel.Brainstormings.BrainstormingAdminUser
+  alias Mindwendel.Brainstormings.BrainstormingModeratingUser
   alias Mindwendel.Brainstormings.Like
 
   @doc """
@@ -33,8 +33,8 @@ defmodule Mindwendel.Brainstormings do
     )
   end
 
-  def add_admin_user(%Brainstorming{} = brainstorming, %User{} = user) do
-    %BrainstormingAdminUser{user_id: user.id, brainstorming_id: brainstorming.id}
+  def add_moderating_user(%Brainstorming{} = brainstorming, %User{} = user) do
+    %BrainstormingModeratingUser{user_id: user.id, brainstorming_id: brainstorming.id}
     |> Ecto.Changeset.change()
     |> Repo.insert()
   end
@@ -288,7 +288,7 @@ defmodule Mindwendel.Brainstormings do
     Repo.get!(Brainstorming, id)
     |> Repo.preload([
       :users,
-      :admin_users,
+      :moderating_users,
       labels: from(idea_label in IdeaLabel, order_by: idea_label.position_order),
       ideas: [
         :link,

--- a/lib/mindwendel/brainstormings/brainstorming.ex
+++ b/lib/mindwendel/brainstormings/brainstorming.ex
@@ -5,6 +5,7 @@ defmodule Mindwendel.Brainstormings.Brainstorming do
   import MindwendelWeb.Gettext
   alias Mindwendel.Brainstormings.Idea
   alias Mindwendel.Brainstormings.IdeaLabel
+  alias Mindwendel.Brainstormings.BrainstormingAdminUser
   alias Mindwendel.Accounts.User
   alias Mindwendel.Accounts.BrainstormingUser
 
@@ -17,6 +18,7 @@ defmodule Mindwendel.Brainstormings.Brainstorming do
     has_many :ideas, Idea
     has_many :labels, IdeaLabel
     many_to_many :users, User, join_through: BrainstormingUser
+    many_to_many :admin_users, User, join_through: BrainstormingAdminUser
 
     timestamps()
   end

--- a/lib/mindwendel/brainstormings/brainstorming.ex
+++ b/lib/mindwendel/brainstormings/brainstorming.ex
@@ -5,7 +5,7 @@ defmodule Mindwendel.Brainstormings.Brainstorming do
   import MindwendelWeb.Gettext
   alias Mindwendel.Brainstormings.Idea
   alias Mindwendel.Brainstormings.IdeaLabel
-  alias Mindwendel.Brainstormings.BrainstormingAdminUser
+  alias Mindwendel.Brainstormings.BrainstormingModeratingUser
   alias Mindwendel.Accounts.User
   alias Mindwendel.Accounts.BrainstormingUser
 
@@ -18,7 +18,7 @@ defmodule Mindwendel.Brainstormings.Brainstorming do
     has_many :ideas, Idea
     has_many :labels, IdeaLabel
     many_to_many :users, User, join_through: BrainstormingUser
-    many_to_many :admin_users, User, join_through: BrainstormingAdminUser
+    many_to_many :moderating_users, User, join_through: BrainstormingModeratingUser
 
     timestamps()
   end

--- a/lib/mindwendel/brainstormings/brainstorming_admin_user.ex
+++ b/lib/mindwendel/brainstormings/brainstorming_admin_user.ex
@@ -1,0 +1,13 @@
+defmodule Mindwendel.Brainstormings.BrainstormingAdminUser do
+  use Ecto.Schema
+  alias Mindwendel.Brainstormings.Brainstorming
+  alias Mindwendel.Accounts.User
+
+  @primary_key false
+  schema "brainstorming_admin_users" do
+    belongs_to :brainstorming, Brainstorming, type: :binary_id
+    belongs_to :user, User, type: :binary_id
+
+    timestamps()
+  end
+end

--- a/lib/mindwendel/brainstormings/brainstorming_moderating_user.ex
+++ b/lib/mindwendel/brainstormings/brainstorming_moderating_user.ex
@@ -1,10 +1,10 @@
-defmodule Mindwendel.Brainstormings.BrainstormingAdminUser do
+defmodule Mindwendel.Brainstormings.BrainstormingModeratingUser do
   use Ecto.Schema
   alias Mindwendel.Brainstormings.Brainstorming
   alias Mindwendel.Accounts.User
 
   @primary_key false
-  schema "brainstorming_admin_users" do
+  schema "brainstorming_moderating_users" do
     belongs_to :brainstorming, Brainstorming, type: :binary_id
     belongs_to :user, User, type: :binary_id
 

--- a/lib/mindwendel/brainstormings/brainstorming_moderating_user.ex
+++ b/lib/mindwendel/brainstormings/brainstorming_moderating_user.ex
@@ -10,4 +10,13 @@ defmodule Mindwendel.Brainstormings.BrainstormingModeratingUser do
 
     timestamps()
   end
+
+  def changeset(%__MODULE__{} = brainstorming_moderating_user) do
+    brainstorming_moderating_user
+    |> Ecto.Changeset.cast(%{}, [:brainstorming_id, :user_id])
+    |> Ecto.Changeset.validate_required([:brainstorming_id, :user_id])
+    |> Ecto.Changeset.unique_constraint([:brainstorming_id, :user_id],
+      name: :brainstorming_moderating_users_pkey
+    )
+  end
 end

--- a/lib/mindwendel_web/controllers/brainstorming_controller.ex
+++ b/lib/mindwendel_web/controllers/brainstorming_controller.ex
@@ -1,9 +1,7 @@
 defmodule MindwendelWeb.BrainstormingController do
   use MindwendelWeb, :controller
   alias Mindwendel.Brainstormings
-  alias Mindwendel.Brainstormings.Brainstorming
   alias Mindwendel.Accounts
-  alias Mindwendel.Repo
 
   def create(conn, %{"brainstorming" => brainstorming_params}) do
     current_user =
@@ -11,8 +9,8 @@ defmodule MindwendelWeb.BrainstormingController do
       |> Accounts.get_or_create_user()
 
     with {:ok, brainstorming} <- Brainstormings.create_brainstorming(brainstorming_params),
-         {:ok, _brainstorming_admin_user} <-
-           Brainstormings.add_admin_user(brainstorming, current_user) do
+         {:ok, _brainstorming_moderating_user} <-
+           Brainstormings.add_moderating_user(brainstorming, current_user) do
       conn
       |> put_flash(
         :info,

--- a/lib/mindwendel_web/controllers/brainstorming_controller.ex
+++ b/lib/mindwendel_web/controllers/brainstorming_controller.ex
@@ -1,19 +1,27 @@
 defmodule MindwendelWeb.BrainstormingController do
   use MindwendelWeb, :controller
   alias Mindwendel.Brainstormings
+  alias Mindwendel.Brainstormings.Brainstorming
+  alias Mindwendel.Accounts
+  alias Mindwendel.Repo
 
   def create(conn, %{"brainstorming" => brainstorming_params}) do
-    case Brainstormings.create_brainstorming(brainstorming_params) do
-      {:ok, brainstorming} ->
-        conn
-        |> put_flash(
-          :info,
-          gettext(
-            "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
-          )
-        )
-        |> redirect(to: Routes.brainstorming_show_path(conn, :show, brainstorming))
+    current_user =
+      MindwendelService.SessionService.get_current_user_id(conn)
+      |> Accounts.get_or_create_user()
 
+    with {:ok, brainstorming} <- Brainstormings.create_brainstorming(brainstorming_params),
+         {:ok, _brainstorming_admin_user} <-
+           Brainstormings.add_admin_user(brainstorming, current_user) do
+      conn
+      |> put_flash(
+        :info,
+        gettext(
+          "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
+        )
+      )
+      |> redirect(to: Routes.brainstorming_show_path(conn, :show, brainstorming))
+    else
       {:error, _} ->
         conn
         |> put_flash(

--- a/lib/mindwendel_web/live/idea_live/form_component.ex
+++ b/lib/mindwendel_web/live/idea_live/form_component.ex
@@ -30,12 +30,12 @@ defmodule MindwendelWeb.IdeaLive.FormComponent do
   defp save_idea(socket, :update, idea_params) do
     idea = Brainstormings.get_idea!(idea_params["id"])
 
-    current_user = socket.assigns.current_user
+    %{current_user: current_user, brainstorming: brainstorming} = socket.assigns
 
-    if idea.user_id == current_user.id do
+    if current_user.id in [idea.user_id | brainstorming.admin_users |> Enum.map(& &1.id)] do
       case Brainstormings.update_idea(
              idea,
-             Map.put(idea_params, "user_id", current_user.id)
+             Map.put(idea_params, "user_id", idea.user_id || current_user.id)
            ) do
         {:ok, _idea} ->
           {:noreply,

--- a/lib/mindwendel_web/live/idea_live/form_component.ex
+++ b/lib/mindwendel_web/live/idea_live/form_component.ex
@@ -32,7 +32,7 @@ defmodule MindwendelWeb.IdeaLive.FormComponent do
 
     %{current_user: current_user, brainstorming: brainstorming} = socket.assigns
 
-    if current_user.id in [idea.user_id | brainstorming.admin_users |> Enum.map(& &1.id)] do
+    if current_user.id in [idea.user_id | brainstorming.moderating_users |> Enum.map(& &1.id)] do
       case Brainstormings.update_idea(
              idea,
              Map.put(idea_params, "user_id", idea.user_id || current_user.id)

--- a/lib/mindwendel_web/live/idea_live/index_component.ex
+++ b/lib/mindwendel_web/live/idea_live/index_component.ex
@@ -18,7 +18,9 @@ defmodule MindwendelWeb.IdeaLive.IndexComponent do
   def handle_event("delete", %{"id" => id}, socket) do
     idea = Brainstormings.get_idea!(id)
 
-    if socket.assigns.current_user.id == idea.user_id do
+    %{current_user: current_user, brainstorming: brainstorming} = socket.assigns
+
+    if current_user.id in [idea.user_id | brainstorming.admin_users |> Enum.map(& &1.id)] do
       {:ok, _} = Brainstormings.delete_idea(idea)
     end
 

--- a/lib/mindwendel_web/live/idea_live/index_component.ex
+++ b/lib/mindwendel_web/live/idea_live/index_component.ex
@@ -20,7 +20,7 @@ defmodule MindwendelWeb.IdeaLive.IndexComponent do
 
     %{current_user: current_user, brainstorming: brainstorming} = socket.assigns
 
-    if current_user.id in [idea.user_id | brainstorming.admin_users |> Enum.map(& &1.id)] do
+    if current_user.id in [idea.user_id | brainstorming.moderating_users |> Enum.map(& &1.id)] do
       {:ok, _} = Brainstormings.delete_idea(idea)
     end
 

--- a/lib/mindwendel_web/live/idea_live/index_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/index_component.html.heex
@@ -4,7 +4,7 @@
       <div class="col-md-6">
         <div class="card mt-3 shadow-sm p-2 rounded IndexComponent__IdeaCard" data-testid={idea.id}>
           <div class="card-body-mindwendel-idea">
-            <%= if idea.user_id == @current_user.id do %>
+            <%= if @brainstorming.admin_users |> Enum.map(fn admin_user -> admin_user.id end) |> Enum.concat([idea.user_id]) |> Enum.member?(@current_user.id) do %>
               <%= link to: "#", class: "float-end ms-3 mb-3", phx_click: "delete", phx_target: @myself, phx_value_id: idea.id, title: 'Delete', data: [confirm: gettext("Are you sure you want to delete this idea?")] do %>
                 <i class="bi bi-x text-secondary"></i>
               <% end %>

--- a/lib/mindwendel_web/live/idea_live/index_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/index_component.html.heex
@@ -4,7 +4,7 @@
       <div class="col-md-6">
         <div class="card mt-3 shadow-sm p-2 rounded IndexComponent__IdeaCard" data-testid={idea.id}>
           <div class="card-body-mindwendel-idea">
-            <%= if @brainstorming.admin_users |> Enum.map(fn admin_user -> admin_user.id end) |> Enum.concat([idea.user_id]) |> Enum.member?(@current_user.id) do %>
+            <%= if @brainstorming.moderating_users |> Enum.map(fn moderating_user -> moderating_user.id end) |> Enum.concat([idea.user_id]) |> Enum.member?(@current_user.id) do %>
               <%= link to: "#", class: "float-end ms-3 mb-3", phx_click: "delete", phx_target: @myself, phx_value_id: idea.id, title: 'Delete', data: [confirm: gettext("Are you sure you want to delete this idea?")] do %>
                 <i class="bi bi-x text-secondary"></i>
               <% end %>

--- a/lib/mindwendel_web/live/idea_live/index_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/index_component.html.heex
@@ -4,7 +4,7 @@
       <div class="col-md-6">
         <div class="card mt-3 shadow-sm p-2 rounded IndexComponent__IdeaCard" data-testid={idea.id}>
           <div class="card-body-mindwendel-idea">
-            <%= if @brainstorming.moderating_users |> Enum.map(fn moderating_user -> moderating_user.id end) |> Enum.concat([idea.user_id]) |> Enum.member?(@current_user.id) do %>
+            <%= if @current_user.id in [idea.user_id | @brainstorming.moderating_users |> Enum.map(& &1.id)] do %>
               <%= link to: "#", class: "float-end ms-3 mb-3", phx_click: "delete", phx_target: @myself, phx_value_id: idea.id, title: 'Delete', data: [confirm: gettext("Are you sure you want to delete this idea?")] do %>
                 <i class="bi bi-x text-secondary"></i>
               <% end %>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -175,7 +175,7 @@ msgstr "Deine Brainstormings"
 msgid "mindwendel could not be found."
 msgstr "mindwendel konnte nicht gefunden werden."
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:29
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Something went wrong when creating a brainstorming. Please try again."
 msgstr "Leider gab es einen Fehler beim Erstellen des Brainstormings. Bitte probiere es erneut."
@@ -185,7 +185,7 @@ msgstr "Leider gab es einen Fehler beim Erstellen des Brainstormings. Bitte prob
 msgid "Successfully deleted brainstorming."
 msgstr "Brainstorming erfolgreich gelöscht"
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:19
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:17
 #, elixir-autogen, elixir-format
 msgid "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
 msgstr "Dein Brainstorming wurde erstellt! Teile den Link mit anderen Personen und legt los."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -175,7 +175,7 @@ msgstr "Deine Brainstormings"
 msgid "mindwendel could not be found."
 msgstr "mindwendel konnte nicht gefunden werden."
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:21
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Something went wrong when creating a brainstorming. Please try again."
 msgstr "Leider gab es einen Fehler beim Erstellen des Brainstormings. Bitte probiere es erneut."
@@ -185,7 +185,7 @@ msgstr "Leider gab es einen Fehler beim Erstellen des Brainstormings. Bitte prob
 msgid "Successfully deleted brainstorming."
 msgstr "Brainstorming erfolgreich gelöscht"
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:11
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:19
 #, elixir-autogen, elixir-format
 msgid "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
 msgstr "Dein Brainstorming wurde erstellt! Teile den Link mit anderen Personen und legt los."
@@ -266,27 +266,27 @@ msgstr "Editiere Brainstorming Labels"
 msgid "Type the label name"
 msgstr "Gebe dem Label einen Namen"
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:56
+#: lib/mindwendel/brainstormings/brainstorming.ex:58
 #, elixir-autogen, elixir-format
 msgid "cyan"
 msgstr "Cyan"
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:57
+#: lib/mindwendel/brainstormings/brainstorming.ex:59
 #, elixir-autogen, elixir-format
 msgid "gray dark"
 msgstr "Dunkelgrau"
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:58
+#: lib/mindwendel/brainstormings/brainstorming.ex:60
 #, elixir-autogen, elixir-format
 msgid "green"
 msgstr "Grün"
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:59
+#: lib/mindwendel/brainstormings/brainstorming.ex:61
 #, elixir-autogen, elixir-format
 msgid "red"
 msgstr "Rot"
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:60
+#: lib/mindwendel/brainstormings/brainstorming.ex:62
 #, elixir-autogen, elixir-format
 msgid "yellow"
 msgstr "Gelb"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -174,7 +174,7 @@ msgstr ""
 msgid "mindwendel could not be found."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:29
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Something went wrong when creating a brainstorming. Please try again."
 msgstr ""
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Successfully deleted brainstorming."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:19
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:17
 #, elixir-autogen, elixir-format
 msgid "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -174,7 +174,7 @@ msgstr ""
 msgid "mindwendel could not be found."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:21
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Something went wrong when creating a brainstorming. Please try again."
 msgstr ""
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Successfully deleted brainstorming."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:11
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:19
 #, elixir-autogen, elixir-format
 msgid "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
 msgstr ""
@@ -265,27 +265,27 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:56
+#: lib/mindwendel/brainstormings/brainstorming.ex:58
 #, elixir-autogen, elixir-format
 msgid "cyan"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:57
+#: lib/mindwendel/brainstormings/brainstorming.ex:59
 #, elixir-autogen, elixir-format
 msgid "gray dark"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:58
+#: lib/mindwendel/brainstormings/brainstorming.ex:60
 #, elixir-autogen, elixir-format
 msgid "green"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:59
+#: lib/mindwendel/brainstormings/brainstorming.ex:61
 #, elixir-autogen, elixir-format
 msgid "red"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:60
+#: lib/mindwendel/brainstormings/brainstorming.ex:62
 #, elixir-autogen, elixir-format
 msgid "yellow"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -175,7 +175,7 @@ msgstr ""
 msgid "mindwendel could not be found."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:21
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Something went wrong when creating a brainstorming. Please try again."
 msgstr ""
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Successfully deleted brainstorming."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:11
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:19
 #, elixir-autogen, elixir-format
 msgid "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
 msgstr ""
@@ -266,27 +266,27 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:56
+#: lib/mindwendel/brainstormings/brainstorming.ex:58
 #, elixir-autogen, elixir-format
 msgid "cyan"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:57
+#: lib/mindwendel/brainstormings/brainstorming.ex:59
 #, elixir-autogen, elixir-format
 msgid "gray dark"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:58
+#: lib/mindwendel/brainstormings/brainstorming.ex:60
 #, elixir-autogen, elixir-format
 msgid "green"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:59
+#: lib/mindwendel/brainstormings/brainstorming.ex:61
 #, elixir-autogen, elixir-format
 msgid "red"
 msgstr ""
 
-#: lib/mindwendel/brainstormings/brainstorming.ex:60
+#: lib/mindwendel/brainstormings/brainstorming.ex:62
 #, elixir-autogen, elixir-format
 msgid "yellow"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -175,7 +175,7 @@ msgstr ""
 msgid "mindwendel could not be found."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:29
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Something went wrong when creating a brainstorming. Please try again."
 msgstr ""
@@ -185,7 +185,7 @@ msgstr ""
 msgid "Successfully deleted brainstorming."
 msgstr ""
 
-#: lib/mindwendel_web/controllers/brainstorming_controller.ex:19
+#: lib/mindwendel_web/controllers/brainstorming_controller.ex:17
 #, elixir-autogen, elixir-format
 msgid "Your brainstorming was created successfully! Share the link with other people and start brainstorming."
 msgstr ""

--- a/priv/repo/migrations/20221220151400_create_brainstorming_admin_users.exs
+++ b/priv/repo/migrations/20221220151400_create_brainstorming_admin_users.exs
@@ -1,0 +1,25 @@
+defmodule Mindwendel.Repo.Migrations.CreateBrainstormingAdminUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:brainstorming_admin_users, primary_key: false) do
+      add(:brainstorming_id, references(:brainstormings, type: :uuid, on_delete: :delete_all),
+        primary_key: true
+      )
+
+      add(:user_id, references(:users, type: :uuid), primary_key: true)
+
+      timestamps()
+    end
+
+    create(index(:brainstorming_admin_users, [:brainstorming_id]))
+    create(index(:brainstorming_admin_users, [:user_id]))
+
+    create(
+      unique_index(:brainstorming_admin_users, [
+        :brainstorming_id,
+        :user_id
+      ])
+    )
+  end
+end

--- a/priv/repo/migrations/20221220151400_create_brainstorming_moderating_users.exs
+++ b/priv/repo/migrations/20221220151400_create_brainstorming_moderating_users.exs
@@ -1,8 +1,8 @@
-defmodule Mindwendel.Repo.Migrations.CreateBrainstormingAdminUsers do
+defmodule Mindwendel.Repo.Migrations.CreateBrainstormingModeratingUsers do
   use Ecto.Migration
 
   def change do
-    create table(:brainstorming_admin_users, primary_key: false) do
+    create table(:brainstorming_moderating_users, primary_key: false) do
       add(:brainstorming_id, references(:brainstormings, type: :uuid, on_delete: :delete_all),
         primary_key: true
       )
@@ -12,11 +12,11 @@ defmodule Mindwendel.Repo.Migrations.CreateBrainstormingAdminUsers do
       timestamps()
     end
 
-    create(index(:brainstorming_admin_users, [:brainstorming_id]))
-    create(index(:brainstorming_admin_users, [:user_id]))
+    create(index(:brainstorming_moderating_users, [:brainstorming_id]))
+    create(index(:brainstorming_moderating_users, [:user_id]))
 
     create(
-      unique_index(:brainstorming_admin_users, [
+      unique_index(:brainstorming_moderating_users, [
         :brainstorming_id,
         :user_id
       ])

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -59,10 +59,10 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: brainstorming_admin_users; Type: TABLE; Schema: public; Owner: -
+-- Name: brainstorming_moderating_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.brainstorming_admin_users (
+CREATE TABLE public.brainstorming_moderating_users (
     brainstorming_id uuid NOT NULL,
     user_id uuid NOT NULL,
     inserted_at timestamp(0) without time zone NOT NULL,
@@ -283,11 +283,11 @@ ALTER TABLE ONLY public.oban_jobs ALTER COLUMN id SET DEFAULT nextval('public.ob
 
 
 --
--- Name: brainstorming_admin_users brainstorming_admin_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: brainstorming_moderating_users brainstorming_moderating_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.brainstorming_admin_users
-    ADD CONSTRAINT brainstorming_admin_users_pkey PRIMARY KEY (brainstorming_id, user_id);
+ALTER TABLE ONLY public.brainstorming_moderating_users
+    ADD CONSTRAINT brainstorming_moderating_users_pkey PRIMARY KEY (brainstorming_id, user_id);
 
 
 --
@@ -387,24 +387,24 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: brainstorming_admin_users_brainstorming_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: brainstorming_moderating_users_brainstorming_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX brainstorming_admin_users_brainstorming_id_index ON public.brainstorming_admin_users USING btree (brainstorming_id);
-
-
---
--- Name: brainstorming_admin_users_brainstorming_id_user_id_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX brainstorming_admin_users_brainstorming_id_user_id_index ON public.brainstorming_admin_users USING btree (brainstorming_id, user_id);
+CREATE INDEX brainstorming_moderating_users_brainstorming_id_index ON public.brainstorming_moderating_users USING btree (brainstorming_id);
 
 
 --
--- Name: brainstorming_admin_users_user_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: brainstorming_moderating_users_brainstorming_id_user_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX brainstorming_admin_users_user_id_index ON public.brainstorming_admin_users USING btree (user_id);
+CREATE UNIQUE INDEX brainstorming_moderating_users_brainstorming_id_user_id_index ON public.brainstorming_moderating_users USING btree (brainstorming_id, user_id);
+
+
+--
+-- Name: brainstorming_moderating_users_user_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX brainstorming_moderating_users_user_id_index ON public.brainstorming_moderating_users USING btree (user_id);
 
 
 --
@@ -499,19 +499,19 @@ CREATE TRIGGER oban_notify AFTER INSERT ON public.oban_jobs FOR EACH ROW EXECUTE
 
 
 --
--- Name: brainstorming_admin_users brainstorming_admin_users_brainstorming_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: brainstorming_moderating_users brainstorming_moderating_users_brainstorming_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.brainstorming_admin_users
-    ADD CONSTRAINT brainstorming_admin_users_brainstorming_id_fkey FOREIGN KEY (brainstorming_id) REFERENCES public.brainstormings(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.brainstorming_moderating_users
+    ADD CONSTRAINT brainstorming_moderating_users_brainstorming_id_fkey FOREIGN KEY (brainstorming_id) REFERENCES public.brainstormings(id) ON DELETE CASCADE;
 
 
 --
--- Name: brainstorming_admin_users brainstorming_admin_users_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: brainstorming_moderating_users brainstorming_moderating_users_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.brainstorming_admin_users
-    ADD CONSTRAINT brainstorming_admin_users_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+ALTER TABLE ONLY public.brainstorming_moderating_users
+    ADD CONSTRAINT brainstorming_moderating_users_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -38,6 +38,50 @@ defmodule Mindwendel.BrainstormingsTest do
     end
   end
 
+  describe "create_brainstorming" do
+    test "empty admin_users", %{brainstorming: brainstorming} do
+      brainstorming = Repo.preload(brainstorming, :admin_users)
+      assert Enum.empty?(brainstorming.admin_users)
+    end
+
+    # test "create a valid brainstorming with admin_user", %{
+    #   brainstorming: brainstorming,
+    #   user: user
+    # } do
+    #   Brainstorming.add_admin_user(brainstorming, user_id)
+
+    #   brainstorming = Repo.preload(brainstorming, :admin_users)
+    #   # brainstorming |> IO.inspect()
+
+    #   {:ok, brainstormin_2} =
+    #     Ecto.Changeset.change(brainstorming)
+    #     |> IO.inspect()
+    #     |> Ecto.Changeset.put_assoc(:admin_users, [user])
+    #     |> IO.inspect()
+    #     |> Mindwendel.Repo.update()
+
+    #   # {:ok, brainstormin_2} = brainstorming |> IO.inspect()
+
+    #   assert Repo.exists?(
+    #            from b in Mindwendel.Brainstormings.BrainstormingAdminUser,
+    #              where: b.brainstorming_id == ^brainstorming.id
+    #          )
+    # end
+  end
+
+  describe "#add_admin_user" do
+    test "adds a user to the brainstorming", %{
+      brainstorming: brainstorming,
+      user: %User{id: user_id} = user
+    } do
+      Brainstormings.add_admin_user(brainstorming, user)
+
+      brainstorming = Repo.preload(brainstorming, :admin_users)
+      assert brainstorming.admin_users |> Enum.map(fn u -> u.id end) == [user.id]
+      assert [%User{id: ^user_id}] = brainstorming.admin_users
+    end
+  end
+
   describe "change brainstorming" do
     test "shortens the brainstorming name if it is too long", %{brainstorming: brainstorming} do
       result =

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -1,5 +1,6 @@
 defmodule Mindwendel.BrainstormingsTest do
   use Mindwendel.DataCase
+  alias Mindwendel.Brainstormings.BrainstormingModeratingUser
   alias Mindwendel.Factory
 
   alias Mindwendel.Brainstormings
@@ -70,15 +71,34 @@ defmodule Mindwendel.BrainstormingsTest do
   end
 
   describe "#add_moderating_user" do
-    test "adds a user to the brainstorming", %{
+    test "adds a moderating user to the brainstorming", %{
       brainstorming: brainstorming,
       user: %User{id: user_id} = user
     } do
       Brainstormings.add_moderating_user(brainstorming, user)
 
+      assert 1 = Repo.one(from(bmu in BrainstormingModeratingUser, select: count(bmu.user_id)))
+      assert brainstorming_moderatoring_user = Repo.one(BrainstormingModeratingUser)
+      assert brainstorming_moderatoring_user.user_id == user.id
+      assert brainstorming_moderatoring_user.brainstorming_id == brainstorming.id
+
       brainstorming = Repo.preload(brainstorming, :moderating_users)
-      assert brainstorming.moderating_users |> Enum.map(fn u -> u.id end) == [user.id]
       assert [%User{id: ^user_id}] = brainstorming.moderating_users
+    end
+
+    test "responds with an error when brainstorming already contains the moderating user", %{
+      brainstorming: brainstorming,
+      user: user
+    } do
+      Brainstormings.add_moderating_user(brainstorming, user)
+
+      assert {:error,
+              %Ecto.Changeset{
+                valid?: false,
+                errors: [
+                  brainstorming_id: {_, [{:constraint, :unique}, _]}
+                ]
+              }} = Brainstormings.add_moderating_user(brainstorming, user)
     end
   end
 
@@ -253,7 +273,7 @@ defmodule Mindwendel.BrainstormingsTest do
       old_brainstorming = Factory.insert!(:brainstorming, inserted_at: ~N[2021-01-01 10:00:00])
       Brainstormings.delete_old_brainstormings()
 
-      refute Repo.exists?(from b in Brainstorming, where: b.id == ^old_brainstorming.id)
+      refute Repo.exists?(from(b in Brainstorming, where: b.id == ^old_brainstorming.id))
     end
 
     test "removes the old brainstormings ideas" do
@@ -267,7 +287,7 @@ defmodule Mindwendel.BrainstormingsTest do
 
       Brainstormings.delete_old_brainstormings()
 
-      refute Repo.exists?(from i in Idea, where: i.id == ^old_idea.id)
+      refute Repo.exists?(from(i in Idea, where: i.id == ^old_idea.id))
     end
 
     test "removes the old brainstormings likes" do
@@ -282,7 +302,7 @@ defmodule Mindwendel.BrainstormingsTest do
       old_like = Factory.insert!(:like, idea: old_idea)
       Brainstormings.delete_old_brainstormings()
 
-      refute Repo.exists?(from l in Like, where: l.id == ^old_like.id)
+      refute Repo.exists?(from(l in Like, where: l.id == ^old_like.id))
     end
 
     test "removes the old brainstormings links" do
@@ -297,7 +317,7 @@ defmodule Mindwendel.BrainstormingsTest do
       old_link = Factory.insert!(:link, idea: old_idea)
       Brainstormings.delete_old_brainstormings()
 
-      refute Repo.exists?(from l in Link, where: l.id == ^old_link.id)
+      refute Repo.exists?(from(l in Link, where: l.id == ^old_link.id))
     end
 
     test "removes the old brainstormings users connection", %{user: user} do
@@ -313,13 +333,13 @@ defmodule Mindwendel.BrainstormingsTest do
       Factory.insert!(:brainstorming, users: [user], inserted_at: ~N[2021-01-01 10:00:00])
       Brainstormings.delete_old_brainstormings()
 
-      assert Repo.exists?(from u in User, where: u.id == ^user.id)
+      assert Repo.exists?(from(u in User, where: u.id == ^user.id))
     end
 
     test "keeps the new brainstorming", %{brainstorming: brainstorming} do
       Brainstormings.delete_old_brainstormings()
 
-      assert Repo.exists?(from b in Brainstorming, where: b.id == ^brainstorming.id)
+      assert Repo.exists?(from(b in Brainstorming, where: b.id == ^brainstorming.id))
     end
   end
 end

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -39,46 +39,46 @@ defmodule Mindwendel.BrainstormingsTest do
   end
 
   describe "create_brainstorming" do
-    test "empty admin_users", %{brainstorming: brainstorming} do
-      brainstorming = Repo.preload(brainstorming, :admin_users)
-      assert Enum.empty?(brainstorming.admin_users)
+    test "empty moderating_users", %{brainstorming: brainstorming} do
+      brainstorming = Repo.preload(brainstorming, :moderating_users)
+      assert Enum.empty?(brainstorming.moderating_users)
     end
 
-    # test "create a valid brainstorming with admin_user", %{
+    # test "create a valid brainstorming with moderating_user", %{
     #   brainstorming: brainstorming,
     #   user: user
     # } do
-    #   Brainstorming.add_admin_user(brainstorming, user_id)
+    #   Brainstorming.add_moderating_user(brainstorming, user_id)
 
-    #   brainstorming = Repo.preload(brainstorming, :admin_users)
+    #   brainstorming = Repo.preload(brainstorming, :moderating_users)
     #   # brainstorming |> IO.inspect()
 
     #   {:ok, brainstormin_2} =
     #     Ecto.Changeset.change(brainstorming)
     #     |> IO.inspect()
-    #     |> Ecto.Changeset.put_assoc(:admin_users, [user])
+    #     |> Ecto.Changeset.put_assoc(:moderating_users, [user])
     #     |> IO.inspect()
     #     |> Mindwendel.Repo.update()
 
     #   # {:ok, brainstormin_2} = brainstorming |> IO.inspect()
 
     #   assert Repo.exists?(
-    #            from b in Mindwendel.Brainstormings.BrainstormingAdminUser,
+    #            from b in Mindwendel.Brainstormings.BrainstormingModeratingUser,
     #              where: b.brainstorming_id == ^brainstorming.id
     #          )
     # end
   end
 
-  describe "#add_admin_user" do
+  describe "#add_moderating_user" do
     test "adds a user to the brainstorming", %{
       brainstorming: brainstorming,
       user: %User{id: user_id} = user
     } do
-      Brainstormings.add_admin_user(brainstorming, user)
+      Brainstormings.add_moderating_user(brainstorming, user)
 
-      brainstorming = Repo.preload(brainstorming, :admin_users)
-      assert brainstorming.admin_users |> Enum.map(fn u -> u.id end) == [user.id]
-      assert [%User{id: ^user_id}] = brainstorming.admin_users
+      brainstorming = Repo.preload(brainstorming, :moderating_users)
+      assert brainstorming.moderating_users |> Enum.map(fn u -> u.id end) == [user.id]
+      assert [%User{id: ^user_id}] = brainstorming.moderating_users
     end
   end
 

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -44,30 +44,6 @@ defmodule Mindwendel.BrainstormingsTest do
       brainstorming = Repo.preload(brainstorming, :moderating_users)
       assert Enum.empty?(brainstorming.moderating_users)
     end
-
-    # test "create a valid brainstorming with moderating_user", %{
-    #   brainstorming: brainstorming,
-    #   user: user
-    # } do
-    #   Brainstorming.add_moderating_user(brainstorming, user_id)
-
-    #   brainstorming = Repo.preload(brainstorming, :moderating_users)
-    #   # brainstorming |> IO.inspect()
-
-    #   {:ok, brainstormin_2} =
-    #     Ecto.Changeset.change(brainstorming)
-    #     |> IO.inspect()
-    #     |> Ecto.Changeset.put_assoc(:moderating_users, [user])
-    #     |> IO.inspect()
-    #     |> Mindwendel.Repo.update()
-
-    #   # {:ok, brainstormin_2} = brainstorming |> IO.inspect()
-
-    #   assert Repo.exists?(
-    #            from b in Mindwendel.Brainstormings.BrainstormingModeratingUser,
-    #              where: b.brainstorming_id == ^brainstorming.id
-    #          )
-    # end
   end
 
   describe "#add_moderating_user" do

--- a/test/mindwendel_web/controllers/brainstorming_controller_test.exs
+++ b/test/mindwendel_web/controllers/brainstorming_controller_test.exs
@@ -18,11 +18,11 @@ defmodule MindwendelWeb.BrainstormingControllerTest do
       assert Repo.one(from b in Brainstorming, select: count(b.id)) == 1
     end
 
-    test "adds current user as admin user to the brainstorming", %{conn: conn} do
+    test "adds current user as moderating user to the brainstorming", %{conn: conn} do
       conn = post(conn, Routes.brainstorming_path(conn, :create), brainstorming: @valid_attrs)
 
-      assert %Brainstorming{admin_users: [%User{id: _}]} =
-               Repo.one(Brainstorming) |> Repo.preload(:admin_users)
+      assert %Brainstorming{moderating_users: [%User{id: _}]} =
+               Repo.one(Brainstorming) |> Repo.preload(:moderating_users)
     end
 
     test "redirects to brainstorming show", %{conn: conn} do

--- a/test/mindwendel_web/controllers/brainstorming_controller_test.exs
+++ b/test/mindwendel_web/controllers/brainstorming_controller_test.exs
@@ -5,6 +5,8 @@ defmodule MindwendelWeb.BrainstormingControllerTest do
 
   alias Mindwendel.Repo
   alias Mindwendel.Brainstormings.Brainstorming
+  alias Mindwendel.Brainstormings
+  alias Mindwendel.Accounts.User
 
   describe "create" do
     @valid_attrs %{name: "How might we fix this?"}
@@ -14,6 +16,13 @@ defmodule MindwendelWeb.BrainstormingControllerTest do
 
       assert Repo.one(Brainstorming).name == @valid_attrs.name
       assert Repo.one(from b in Brainstorming, select: count(b.id)) == 1
+    end
+
+    test "adds current user as admin user to the brainstorming", %{conn: conn} do
+      conn = post(conn, Routes.brainstorming_path(conn, :create), brainstorming: @valid_attrs)
+
+      assert %Brainstorming{admin_users: [%User{id: _}]} =
+               Repo.one(Brainstorming) |> Repo.preload(:admin_users)
     end
 
     test "redirects to brainstorming show", %{conn: conn} do

--- a/test/mindwendel_web/live/brainstorming_live/show_idea_delete_test.exs
+++ b/test/mindwendel_web/live/brainstorming_live/show_idea_delete_test.exs
@@ -1,0 +1,80 @@
+defmodule MindwendelWeb.BrainstormingLive.ShowIdeaDeleteTest do
+  use MindwendelWeb.ConnCase
+  import Phoenix.LiveViewTest
+  alias Mindwendel.Brainstormings
+
+  alias Mindwendel.Factory
+
+  setup %{conn: conn} do
+    brainstorming = Factory.insert!(:brainstorming)
+    current_user_id = Ecto.UUID.generate()
+    user = Factory.insert!(:user, id: current_user_id)
+
+    idea =
+      Factory.insert!(:idea, %{
+        brainstorming: brainstorming,
+        user_id: current_user_id
+      })
+
+    %{
+      brainstorming: brainstorming,
+      current_user_id: current_user_id,
+      conn: conn |> init_test_session(%{current_user_id: current_user_id}),
+      idea: idea,
+      user: user
+    }
+  end
+
+  # <%= link to: "#", class: "float-end ms-3 mb-3", phx_click: "delete", phx_target: @myself, phx_value_id: idea.id, title: 'Delete', data: [confirm: gettext("Are you sure you want to delete this idea?")] do %>
+  #               <i class="bi bi-x text-secondary"></i>
+  #             <% end %>
+
+  test "delete idea as admin user", %{
+    conn: conn,
+    brainstorming: brainstorming
+  } do
+    admin_user = Factory.insert!(:user)
+    Brainstormings.add_admin_user(brainstorming, admin_user)
+
+    {:ok, show_live_view, _html} =
+      conn
+      |> init_test_session(%{current_user_id: admin_user.id})
+      |> live(Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+    rendered =
+      show_live_view
+      |> element(html_selector_button_idea_delete_link())
+      |> render_click()
+
+    refute show_live_view
+           |> element(html_selector_button_idea_delete_link())
+           |> has_element?
+
+    # refute rendered =~ 'Delete'
+
+    # {:ok, show_live_view, _html} =
+    #   conn
+    #   |> init_test_session(%{current_user_id: admin_user.id})
+    #   |> live(Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+    # refute show_live_view
+    #        |> element(html_selector_button_idea_delete_link())
+    #        |> has_element?
+
+    # new_idea_body = "New idea body by Admin"
+
+    # {:ok, show_live_view, _html} =
+    #   show_live_view
+    #   |> form("#idea-form", idea: %{body: new_idea_body})
+    #   |> render_submit()
+    #   |> follow_redirect(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+    # assert show_live_view
+    #        |> element(".card-body-mindwendel-idea", new_idea_body)
+    #        |> has_element?
+  end
+
+  defp html_selector_button_idea_delete_link do
+    "a[@title='Delete']"
+  end
+end

--- a/test/mindwendel_web/live/brainstorming_live/show_idea_delete_test.exs
+++ b/test/mindwendel_web/live/brainstorming_live/show_idea_delete_test.exs
@@ -29,16 +29,16 @@ defmodule MindwendelWeb.BrainstormingLive.ShowIdeaDeleteTest do
   #               <i class="bi bi-x text-secondary"></i>
   #             <% end %>
 
-  test "delete idea as admin user", %{
+  test "delete idea as moderating user", %{
     conn: conn,
     brainstorming: brainstorming
   } do
-    admin_user = Factory.insert!(:user)
-    Brainstormings.add_admin_user(brainstorming, admin_user)
+    moderating_user = Factory.insert!(:user)
+    Brainstormings.add_moderating_user(brainstorming, moderating_user)
 
     {:ok, show_live_view, _html} =
       conn
-      |> init_test_session(%{current_user_id: admin_user.id})
+      |> init_test_session(%{current_user_id: moderating_user.id})
       |> live(Routes.brainstorming_show_path(conn, :show, brainstorming))
 
     rendered =
@@ -54,14 +54,14 @@ defmodule MindwendelWeb.BrainstormingLive.ShowIdeaDeleteTest do
 
     # {:ok, show_live_view, _html} =
     #   conn
-    #   |> init_test_session(%{current_user_id: admin_user.id})
+    #   |> init_test_session(%{current_user_id: moderatoring_user.id})
     #   |> live(Routes.brainstorming_show_path(conn, :show, brainstorming))
 
     # refute show_live_view
     #        |> element(html_selector_button_idea_delete_link())
     #        |> has_element?
 
-    # new_idea_body = "New idea body by Admin"
+    # new_idea_body = "New idea body by moderatoring user"
 
     # {:ok, show_live_view, _html} =
     #   show_live_view

--- a/test/mindwendel_web/live/brainstorming_live/show_idea_edit_test.exs
+++ b/test/mindwendel_web/live/brainstorming_live/show_idea_edit_test.exs
@@ -80,23 +80,23 @@ defmodule MindwendelWeb.BrainstormingLive.ShowIdeaEditTest do
            |> has_element?
   end
 
-  test "edit and update text as admin user", %{
+  test "edit and update text as moderatoring user", %{
     conn: conn,
     brainstorming: brainstorming
   } do
-    admin_user = Factory.insert!(:user)
-    Brainstormings.add_admin_user(brainstorming, admin_user)
+    moderatoring_user = Factory.insert!(:user)
+    Brainstormings.add_moderating_user(brainstorming, moderatoring_user)
 
     {:ok, show_live_view, _html} =
       conn
-      |> init_test_session(%{current_user_id: admin_user.id})
+      |> init_test_session(%{current_user_id: moderatoring_user.id})
       |> live(Routes.brainstorming_show_path(conn, :show, brainstorming))
 
     assert show_live_view
            |> element(html_selector_button_idea_edit_link())
            |> render_click()
 
-    new_idea_body = "New idea body by Admin"
+    new_idea_body = "New idea body by moderator"
 
     {:ok, show_live_view, _html} =
       show_live_view
@@ -109,25 +109,25 @@ defmodule MindwendelWeb.BrainstormingLive.ShowIdeaEditTest do
            |> has_element?
   end
 
-  test "does not change user owner of idea after updating text as admin user", %{
+  test "does not change user owner of idea after updating text as moderator user", %{
     conn: conn,
     brainstorming: brainstorming,
     idea: idea,
     user: %User{id: user_id}
   } do
-    admin_user = Factory.insert!(:user)
-    Brainstormings.add_admin_user(brainstorming, admin_user)
+    moderator_user = Factory.insert!(:user)
+    Brainstormings.add_moderating_user(brainstorming, moderator_user)
 
     {:ok, show_live_view, _html} =
       conn
-      |> init_test_session(%{current_user_id: admin_user.id})
+      |> init_test_session(%{current_user_id: moderator_user.id})
       |> live(Routes.brainstorming_show_path(conn, :show, brainstorming))
 
     assert show_live_view
            |> element(html_selector_button_idea_edit_link())
            |> render_click()
 
-    new_idea_body = "New idea body by Admin"
+    new_idea_body = "New idea body by moderator"
 
     {:ok, show_live_view, _html} =
       show_live_view
@@ -140,7 +140,7 @@ defmodule MindwendelWeb.BrainstormingLive.ShowIdeaEditTest do
            |> has_element?
 
     assert Mindwendel.Brainstormings.get_idea!(idea.id).user_id
-    assert admin_user.id != Mindwendel.Brainstormings.get_idea!(idea.id).user_id
+    assert moderator_user.id != Mindwendel.Brainstormings.get_idea!(idea.id).user_id
     assert user_id = Mindwendel.Brainstormings.get_idea!(idea.id).user_id
   end
 


### PR DESCRIPTION
## Further Notes

- When a brainstorming is created, the creating user is saved
- Additional moderators are considered in the 

## New Features / Enhancements

- [x] Following all requirements from the checklist in #149 

## After Merge Checklist

- [ ] [Refactoring] Consider introducing authorization library, e.g. canada or bodyguard
- [ ] [Refactoring] Organize the `Repo` code; currently, there is a lot of code duplication that coudl be addressed following the best practices of other elixir phoenix projects
- [ ] [Refactoring] Consider using domains to organize the translations file better
- [ ] [Refactoring] Refactor factories