### PR TITLE
209 deployment add annotations to docker images 2

### DIFF
--- a/.github/workflows/on_push_main_publish.yml
+++ b/.github/workflows/on_push_main_publish.yml
@@ -6,7 +6,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `master`.
 on:
   push:
-    branches: ["master"]
+    branches: ["209-deployment-add-annotations-to-docker-images-2"]
   release:
     types: [published]
 
@@ -51,6 +51,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             #semver for tag:
             type=semver,pattern={{version}}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.

--- a/.github/workflows/on_push_main_publish.yml
+++ b/.github/workflows/on_push_main_publish.yml
@@ -6,7 +6,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `master`.
 on:
   push:
-    branches: ["209-deployment-add-annotations-to-docker-images-2"]
+    branches: ["master"]
   release:
     types: [published]
 

--- a/.github/workflows/on_push_main_publish.yml
+++ b/.github/workflows/on_push_main_publish.yml
@@ -29,6 +29,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.12.0
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry


### PR DESCRIPTION
## Further Notes

- Force buildx 0.12.0, otherwise annotations are not supported

## New Features / Enhancements

- https://github.com/b310-digital/mindwendel/pkgs/container/mindwendel

## After Merge Checklist

- [X] Annotations are added
