### PR TITLE
chore: ignore devcontainer files #230

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -80,3 +80,6 @@ elixir_buildpack.config
 phoenix_static_buildpack.config
 
 docker-compose*.yml
+
+# ignore devcontainer files:
+.devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docker-compose.override.yml
 docker-compose*.override.yml
 
 ca
+
+# devcontainer files:
+.devcontainer


### PR DESCRIPTION
## Further Notes

- Ignores devcontainer files in git and docker build process.
