### PR TITLE
bug: fix flash alerts after phoenix 1.7 upgrade

### DIFF
--- a/lib/mindwendel_web.ex
+++ b/lib/mindwendel_web.ex
@@ -35,7 +35,7 @@ defmodule MindwendelWeb do
 
       # Import convenience functions from controllers
       import Phoenix.Controller,
-        only: [get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]
+        only: [view_module: 1, view_template: 1]
 
       # Include shared imports and aliases for views
       unquote(view_helpers())

--- a/lib/mindwendel_web/templates/layout/app.html.heex
+++ b/lib/mindwendel_web/templates/layout/app.html.heex
@@ -1,5 +1,9 @@
 <main role="main" class="container">
-  <p class="alert alert-info" role="alert"><%= Phoenix.Flash.get(@flash, :info) %></p>
-  <p class="alert alert-danger" role="alert"><%= Phoenix.Flash.get(@flash, :error) %></p>
+  <%= if Phoenix.Flash.get(@flash, :info) do %>
+    <p class="alert alert-info" role="alert"><%= Phoenix.Flash.get(@flash, :info) %></p>
+  <% end %>
+  <%= if Phoenix.Flash.get(@flash, :error) do %>
+    <p class="alert alert-danger" role="alert"><%= Phoenix.Flash.get(@flash, :error) %></p>
+  <% end %>
   <%= @inner_content %>
 </main>

--- a/lib/mindwendel_web/templates/layout/live.html.heex
+++ b/lib/mindwendel_web/templates/layout/live.html.heex
@@ -1,11 +1,13 @@
 <main role="main" class="container" id="main-container">
-  <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-    <%= live_flash(@flash, :info) %>
-  </p>
-
-  <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-    <%= live_flash(@flash, :error) %>
-  </p>
-
+  <%= if live_flash(@flash, :info) do %>
+    <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
+      <%= live_flash(@flash, :info) %>
+    </p>
+  <% end %>
+  <%= if live_flash(@flash, :error) do %>
+    <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
+      <%= live_flash(@flash, :error) %>
+    </p>
+  <% end %>
   <%= @inner_content %>
 </main>


### PR DESCRIPTION
## Further Notes

- Phoenix 1.7 changed the way flash messages are handled. This lead to empty, but visible alert boxes in bootstrap.

## New Features / Enhancements

- To fix this, the code now validates whether the flash is set before rendering the alerts
