### PR TITLE
chore: upgrade elixir, otp and debian

### DIFF
--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -37,7 +37,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bullseye-20230612-slim
+    container: hexpm/elixir:1.15.7-erlang-26.2.2-debian-bullseye-20240130-slim
 
     needs: build_deps
 
@@ -87,7 +87,7 @@ jobs:
 
   check_mix_format:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bullseye-20230612-slim
+    container: hexpm/elixir:1.15.7-erlang-26.2.2-debian-bullseye-20240130-slim
 
     needs: build_deps
 
@@ -107,7 +107,7 @@ jobs:
   
   check_mix_gettext_extract_up_to_date:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bullseye-20230612-slim
+    container: hexpm/elixir:1.15.7-erlang-26.2.2-debian-bullseye-20240130-slim
 
     needs: build_deps
 
@@ -127,7 +127,7 @@ jobs:
 
   check_mix_sobelow:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bullseye-20230612-slim
+    container: hexpm/elixir:1.15.7-erlang-26.2.2-debian-bullseye-20240130-slim
 
     needs: build_deps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.1-erlang-24.2-debian-bullseye-20210902-slim
 #
-ARG ELIXIR_VERSION=1.15.2
-ARG OTP_VERSION=26.0.2
-ARG DEBIAN_VERSION=bullseye-20230612-slim
+ARG ELIXIR_VERSION=1.15.7
+ARG OTP_VERSION=26.2.2
+ARG DEBIAN_VERSION=bullseye-20240130-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
## Further Notes
Updates the following packages:

ELIXIR_VERSION=1.15.7
OTP_VERSION=26.2.2
DEBIAN_VERSION=bullseye-20240130-slim

## After Merge Checklist

- [ ] Check successful image build
