### PR TITLE
bug: Don't underline X in new idea modal #190

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -19,13 +19,15 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.7.10",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.3.3"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1"
+      "version": "0.18.18",
+      "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",

--- a/lib/mindwendel_web/live/modal_component.ex
+++ b/lib/mindwendel_web/live/modal_component.ex
@@ -16,7 +16,7 @@ defmodule MindwendelWeb.ModalComponent do
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title"><%= assigns.opts[:title] %></h5>
-            <%= live_patch(raw("&times;"), to: @return_to, class: "phx-modal-close") %>
+            <%= live_patch("", to: @return_to, class: "phx-modal-close btn-close") %>
           </div>
           <div class="modal-body">
             <%= live_component(@component, @opts) %>


### PR DESCRIPTION
## Further Notes

- Closes #190

## New Features / Enhancements

- This PR replaces the text X with the proper bootstrap class, so that bootstrap takes over the alignment and styling.

## After Merge Checklist

- [x] test in staging/prod
