### PR TITLE
chore: Remove csp directive script-src 'unsafe-eval' in project #139

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,12 +15,12 @@ import { Modal } from "bootstrap"
 //
 
 import "phoenix_html"
-import {Socket} from "phoenix"
+import { Socket } from "phoenix"
 import NProgress from "nprogress"
-import {LiveSocket} from "phoenix_live_view"
+import { LiveSocket } from "phoenix_live_view"
 import QRCodeStyling from "qr-code-styling";
 import ClipboardJS from "clipboard"
-import {buildQrCodeOptions} from "./qrCodeUtils.js"
+import { buildQrCodeOptions } from "./qrCodeUtils.js"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 
@@ -39,12 +39,12 @@ Hooks.NativeSharingButton = {
       text: this.el.getAttribute(`data-native-sharing-button-share-data-text`) || 'Join my brainstorming',
       url: this.el.getAttribute(`data-native-sharing-button-share-data-url`) || document.getElementById("brainstorming-link").value
     }
-     
+
     if (navigator.share) {
       this.el.addEventListener('click', (event) => {
         navigator.share(shareData)
-        .then() // Do nothing
-        .catch(err => { console.log(`Error: ${err}`) }) 
+          .then() // Do nothing
+          .catch(err => { console.log(`Error: ${err}`) })
       })
     }
   }
@@ -59,17 +59,17 @@ Hooks.Modal = {
     // See https://fullstackphoenix.com/tutorials/create-a-reusable-modal-with-liveview-component
     const modal = new Modal(this.el, { backdrop: 'static', keyboard: false })
     modal.show()
-    
+
     const hideModal = () => modal && modal.hide()
-    
+
     this.el.addEventListener('submit', hideModal)
 
     const formCancelElement = this.el.querySelector(".form-cancel")
     formCancelElement && formCancelElement.addEventListener('click', hideModal)
-    
+
     const phxModalCloseElement = this.el.querySelector(".phx-modal-close")
     phxModalCloseElement && phxModalCloseElement.addEventListener('click', hideModal)
-    
+
     this.el.addEventListener('keyup', (keyEvent) => {
       if (keyEvent.key === 'Escape') {
         // This will tell the "#modal" div to send a "close" event to the server
@@ -77,7 +77,7 @@ Hooks.Modal = {
         hideModal()
       }
     })
-    
+
     window.addEventListener('popstate', () => {
       hideModal()
       // To avoid multiple registers
@@ -90,10 +90,10 @@ Hooks.QrCodeCanvas = {
   mounted() {
     const qrCodeCanvasElement = this.el
     const qrCodeUrl = qrCodeCanvasElement.getAttribute("data-qr-code-url")
-    
+
     const qrCodeOptions = buildQrCodeOptions(qrCodeUrl)
     const qrCode = new QRCodeStyling(qrCodeOptions)
-            
+
     qrCode.append(qrCodeCanvasElement);
   }
 }
@@ -103,19 +103,33 @@ Hooks.QrCodeDownloadButton = {
     const qrCodeUrl = this.el.getAttribute("data-qr-code-url");
     const qrCodeFilename = this.el.getAttribute("data-qr-code-filename") || qrCodeUrl || "qrcode";
     const qrCodeFileExtension = this.el.getAttribute("data-qr-code-file-extension") || "png";
-    
+
     const qrCodeOptions = buildQrCodeOptions(qrCodeUrl)
     const qrCode = new QRCodeStyling(qrCodeOptions)
-    
+
     this.el && this.el.addEventListener('click', () => {
       qrCode.download({ name: qrCodeFilename, extension: qrCodeFileExtension })
         .then() // Do nothing
-        .catch(err => { console.log(`Error: ${err}`) }) 
+        .catch(err => { console.log(`Error: ${err}`) })
     })
   }
 }
 
-let liveSocket = new LiveSocket("/live", Socket, { hooks: Hooks, params: {_csrf_token: csrfToken}})
+Hooks.SetIdeaLabelColor = {
+  mounted() {
+    const color = this.el.getAttribute("data-color");
+    this.el.style.color = color;
+  },
+};
+
+Hooks.SetIdeaLabelBackgroundColor = {
+  mounted() {
+    const color = this.el.getAttribute("data-color");
+    this.el.style.backgroundColor = color;
+  },
+};
+
+let liveSocket = new LiveSocket("/live", Socket, { hooks: Hooks, params: { _csrf_token: csrfToken } })
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", info => NProgress.start())
@@ -129,4 +143,3 @@ liveSocket.connect()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
-

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -42,6 +42,7 @@ a .bi {
 .phx-disconnected {
   cursor: wait;
 }
+
 .phx-disconnected * {
   pointer-events: none;
 }
@@ -63,4 +64,12 @@ a .bi {
 /* Alerts and form errors */
 .alert:empty {
   display: none;
+}
+
+.form-control-color {
+  max-width: 50px;
+}
+
+.heading-error {
+  font-size: 8rem;
 }

--- a/assets/scss/live/idea_live/_index_component.scss
+++ b/assets/scss/live/idea_live/_index_component.scss
@@ -53,6 +53,7 @@
 .IndexComponent__IdeaLabel {
   @extend %bi-icon-before;
   @extend %bi-circle-fill-before;
+
   &:hover {
     @extend %bi-plus-circle-fill-before;
   }
@@ -61,7 +62,14 @@
 .IndexComponent__IdeaLabel--active {
   @extend %bi-icon-before;
   @extend %bi-check-circle-fill-before;
+
   &:hover {
     @extend %bi-x-circle-fill-before;
   }
+}
+
+.preview-url {
+  width: 100px;
+  margin: auto;
+  display: block;
 }

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -142,7 +142,9 @@ config :mindwendel, :options,
       ["", "true"],
       String.trim(System.get_env("MW_FEATURE_BRAINSTORMING_TEASER") || "")
     ),
-  feature_brainstorming_removal_after_days: delete_brainstormings_after_days
+  feature_brainstorming_removal_after_days: delete_brainstormings_after_days,
+  # use a strict csp everywhere except in development. we need to relax the setting a bit for webpack
+  csp_relax: config_env() == :dev
 
 if config_env() == :prod || config_env() == :dev do
   config :mindwendel, Oban,

--- a/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex
+++ b/lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex
@@ -120,7 +120,6 @@
               <%= color_input(p, :color,
                 class:
                   "form-control form-control-color #{if p.errors[:color], do: "is-invalid"}  #{if p.source.changes[:name] || p.source.changes[:color], do: "border-success"}",
-                style: "max-width: 50px",
                 title: gettext("Choose the label color")
               ) %>
               <%= text_input(p, :name,

--- a/lib/mindwendel_web/live/idea_live/index_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/index_component.html.heex
@@ -18,9 +18,11 @@
 
             <%= for idea_label <- Enum.sort_by(idea.idea_labels, &(&1.position_order)) do %>
               <span
+                id={"idea-label-#{uuid()}"}
                 class="IndexComponent__IdeaLabelBadge mb-3"
                 data-testid={idea_label.id}
-                style={"background-color: #{idea_label.color}"}
+                data-color={idea_label.color}
+                phx-hook="SetIdeaLabelBackgroundColor"
               >
                 <%= idea_label.name %>
               </span>
@@ -38,7 +40,7 @@
               <div class="row">
                 <div class="col-md-3">
                   <%= img_tag(idea.link.img_preview_url,
-                    style: "width: 100px; margin: auto; display: block;"
+                    class: "preview-url"
                   ) %>
                 </div>
                 <div class="col-md-9">
@@ -73,18 +75,22 @@
                 <%= unless Enum.find(idea.idea_labels, fn idea_label -> idea_label.id == brainstorming_idea_label.id end) do %>
                   <%= link to: "#", class: "text-decoration-none me-1", data_testid: brainstorming_idea_label.id, title: "Label #{brainstorming_idea_label.name}", phx_click: "add_idea_label_to_idea", phx_target: @myself, phx_value_idea_id: idea.id, phx_value_idea_label_id: brainstorming_idea_label.id do %>
                     <i
+                      id={"idea-label-#{uuid()}"}
                       class="IndexComponent__IdeaLabel"
                       data-testid={brainstorming_idea_label.id}
-                      style={"color: #{brainstorming_idea_label.color};"}
+                      data-color={brainstorming_idea_label.color}
+                      phx-hook="SetIdeaLabelColor"
                     >
                     </i>
                   <% end %>
                 <% else %>
                   <%= link to: "#", class: "text-decoration-none me-1", data_testid: brainstorming_idea_label.id, title: "Label #{brainstorming_idea_label.name}", phx_click: "remove_idea_label_from_idea", phx_target: @myself, phx_value_idea_id: idea.id, phx_value_idea_label_id: brainstorming_idea_label.id do %>
                     <i
+                      id={"idea-label-#{uuid()}"}
                       class="IndexComponent__IdeaLabel--active"
                       data-testid={brainstorming_idea_label.id}
-                      style={"color: #{brainstorming_idea_label.color};"}
+                      data-color={brainstorming_idea_label.color}
+                      phx-hook="SetIdeaLabelColor"
                     >
                     </i>
                   <% end %>

--- a/lib/mindwendel_web/live/live_helpers.ex
+++ b/lib/mindwendel_web/live/live_helpers.ex
@@ -20,4 +20,8 @@ defmodule MindwendelWeb.LiveHelpers do
     modal_opts = [id: :modal, return_to: path, component: component, opts: opts]
     live_component(MindwendelWeb.ModalComponent, modal_opts)
   end
+
+  def uuid do
+    Ecto.UUID.generate()
+  end
 end

--- a/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
+++ b/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
@@ -31,14 +31,13 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
       "font-src    'self' ;",
       "frame-src   'self' ;",
 
-      # We add csp sources http: and https: to allow the browser to load the link preview image extracted from the idea body
-      "img-src     'self' data: https: http: ;",
+      # We add csp sources https: to allow the browser to load the link preview image extracted from the idea body
+      "img-src     'self' data: https: ;",
 
       # We need to add csp 'unsafe-eval', otherwise we get an error in development
       # because webpack js bundle uses `eval` for hot reloading.
-      # TODO: Lets evaluate this for production
-      "script-src  'self' 'unsafe-eval' ;",
-      "style-src   'self' 'unsafe-inline' ;"
+      "script-src #{get_script_src()} ;",
+      "style-src #{get_style_src()} ;"
     ]
     |> Enum.join(" ")
   end
@@ -48,6 +47,18 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
     |> Application.fetch_env!(MindwendelWeb.Endpoint)
     |> Keyword.fetch!(:url)
     |> Keyword.fetch!(:host)
+  end
+
+  def get_script_src() do
+    if Application.fetch_env!(:mindwendel, :options)[:csp_relax],
+      do: "'self' 'unsafe-eval'",
+      else: "'self'"
+  end
+
+  def get_style_src() do
+    if Application.fetch_env!(:mindwendel, :options)[:csp_relax],
+      do: "'self' 'unsafe-inline'",
+      else: "'self'"
   end
 
   def get_scheme() do

--- a/lib/mindwendel_web/templates/error/error_page.html.heex
+++ b/lib/mindwendel_web/templates/error/error_page.html.heex
@@ -29,7 +29,7 @@
 
     <main role="main" class="container" id="main-container">
       <div class="text-center">
-        <h1 style="font-size: 8rem;">
+        <h1 class="heading-error">
           <%= for i <- @status |> Integer.to_string |> String.graphemes do %>
             <%= if i == "0" do %>
               <i class="bi-lightbulb-off text-black"></i>

--- a/lib/mindwendel_web/templates/layout/static_page.html.heex
+++ b/lib/mindwendel_web/templates/layout/static_page.html.heex
@@ -21,7 +21,7 @@
     </script>
   </head>
 
-  <body class="d-flex h-100" style="background-color: #000000;">
+  <body class="d-flex h-100 bg-black">
     <%= @inner_content %>
   </body>
 </html>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -41,7 +41,7 @@ msgstr "%{name} - Neue Idee"
 msgid "Are you sure you want to delete this idea?"
 msgstr "Möchtest du die Idee löschen?"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:200
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone"
 msgstr "Achtung: Hiermit löschst du das Brainstorming und alle dazugehörigen Ideen. Diese Aktion kann nicht rückgängig gemacht werden."
@@ -67,22 +67,22 @@ msgstr "Erstelle ein Brainstorming."
 msgid "Create!"
 msgstr "Erstellen!"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:204
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:194
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "Delete Brainstorming"
 msgstr "Lösche Brainstorming"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:178
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Export to CSV"
 msgstr "Export als CSV"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:185
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Export to HTML"
 msgstr "Export als HTML"
@@ -118,7 +118,7 @@ msgstr "Neue Idee"
 msgid "New idea page (Hotkey: i)"
 msgstr "Neue Idee (Hotkey: i)"
 
-#: lib/mindwendel_web/live/idea_live/index_component.html.heex:103
+#: lib/mindwendel_web/live/idea_live/index_component.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "No ideas brainstormed"
 msgstr "Bisher keine Ideen"
@@ -195,7 +195,7 @@ msgstr "Dein Brainstorming wurde erstellt! Teile den Link mit anderen Personen u
 msgid "Edit Brainstorming"
 msgstr "Editiere Brainstorming"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:175
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Export"
@@ -220,7 +220,7 @@ msgstr "Einige Pflichtfelder fehlen oder sind inkorrekt:"
 msgid "Username"
 msgstr "Nutzername"
 
-#: lib/mindwendel_web/live/idea_live/index_component.html.heex:53
+#: lib/mindwendel_web/live/idea_live/index_component.html.heex:55
 #: lib/mindwendel_web/templates/admin/brainstorming/export.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "By"
@@ -251,7 +251,7 @@ msgstr "Brainstorming wird gelöscht in "
 msgid "Brainstormings will be deleted after %{days} days."
 msgstr "Brainstormings werden nach %{days} Tagen gelöscht."
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:124
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Choose the label color"
 msgstr "Wähle die Farbe für das Label aus"
@@ -261,7 +261,7 @@ msgstr "Wähle die Farbe für das Label aus"
 msgid "Edit Brainstorming Labels"
 msgstr "Editiere Brainstorming Labels"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:129
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Type the label name"
 msgstr "Gebe dem Label einen Namen"
@@ -291,19 +291,19 @@ msgstr "Rot"
 msgid "yellow"
 msgstr "Gelb"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:165
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Add idea label"
 msgstr "Neues Label"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:138
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Remove idea label"
 msgstr "Löschen"
 
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:76
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:103
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:154
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Saved"
 msgstr "Gespeichert"
@@ -348,7 +348,7 @@ msgstr "Download als PNG"
 msgid "Download as svg"
 msgstr "Download als SVG"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:205
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming delete are you sure"
 msgstr "Bist du sicher, dass das Brainstorming gelöscht werden soll?"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -40,7 +40,7 @@ msgstr ""
 msgid "Are you sure you want to delete this idea?"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:200
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone"
 msgstr ""
@@ -66,22 +66,22 @@ msgstr ""
 msgid "Create!"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:204
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:194
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "Delete Brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:178
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Export to CSV"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:185
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Export to HTML"
 msgstr ""
@@ -117,7 +117,7 @@ msgstr ""
 msgid "New idea page (Hotkey: i)"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/index_component.html.heex:103
+#: lib/mindwendel_web/live/idea_live/index_component.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "No ideas brainstormed"
 msgstr ""
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Edit Brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:175
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
@@ -219,7 +219,7 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/index_component.html.heex:53
+#: lib/mindwendel_web/live/idea_live/index_component.html.heex:55
 #: lib/mindwendel_web/templates/admin/brainstorming/export.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "By"
@@ -250,7 +250,7 @@ msgstr ""
 msgid "Brainstormings will be deleted after %{days} days."
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:124
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Choose the label color"
 msgstr ""
@@ -260,7 +260,7 @@ msgstr ""
 msgid "Edit Brainstorming Labels"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:129
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Type the label name"
 msgstr ""
@@ -290,19 +290,19 @@ msgstr ""
 msgid "yellow"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:165
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Add idea label"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:138
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Remove idea label"
 msgstr ""
 
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:76
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:103
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:154
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Saved"
 msgstr ""
@@ -347,7 +347,7 @@ msgstr ""
 msgid "Download as svg"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:205
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "Brainstorming delete are you sure"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -41,7 +41,7 @@ msgstr ""
 msgid "Are you sure you want to delete this idea?"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:200
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Attention: This will delete the brainstorming with all belonging ideas and other associated records to it. This cant be undone"
 msgstr ""
@@ -67,22 +67,22 @@ msgstr ""
 msgid "Create!"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:204
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:194
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:193
 #, elixir-autogen, elixir-format
 msgid "Delete Brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:178
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Export to CSV"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:185
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Export to HTML"
 msgstr ""
@@ -118,7 +118,7 @@ msgstr ""
 msgid "New idea page (Hotkey: i)"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/index_component.html.heex:103
+#: lib/mindwendel_web/live/idea_live/index_component.html.heex:109
 #, elixir-autogen, elixir-format
 msgid "No ideas brainstormed"
 msgstr ""
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Edit Brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:175
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/index_component.html.heex:53
+#: lib/mindwendel_web/live/idea_live/index_component.html.heex:55
 #: lib/mindwendel_web/templates/admin/brainstorming/export.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "By"
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Brainstormings will be deleted after %{days} days."
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:124
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Choose the label color"
 msgstr ""
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Edit Brainstorming Labels"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:129
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Type the label name"
 msgstr ""
@@ -291,19 +291,19 @@ msgstr ""
 msgid "yellow"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:165
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Add idea label"
 msgstr ""
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:138
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Remove idea label"
 msgstr "Remove"
 
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:76
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:103
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:154
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Saved"
 msgstr "Saved"
@@ -348,7 +348,7 @@ msgstr "Download as png"
 msgid "Download as svg"
 msgstr "Download as svg"
 
-#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:205
+#: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming delete are you sure"
 msgstr "Are you sure that you want to delete this brainstorming?"

--- a/test/mindwendel_web/live/response_header_content_security_policy_test.exs
+++ b/test/mindwendel_web/live/response_header_content_security_policy_test.exs
@@ -57,7 +57,35 @@ defmodule MindwendelWeb.ResponseHeaderContentSecurityPolicyTest do
 
       assert conn_response
              |> get_resp_header("content-security-policy")
-             |> List.first() =~ ~r/(img-src)\s+('self' data: https: http:) ;/
+             |> List.first() =~ ~r/(img-src)\s+('self' data: https:) ;/
+    end
+  end
+
+  describe "csp directive 'script-src'" do
+    test "allows only self in prod",
+         %{
+           conn: conn,
+           brainstorming: brainstorming
+         } do
+      conn_response = get(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+      assert conn_response
+             |> get_resp_header("content-security-policy")
+             |> List.first() =~ ~r/(script-src)\s+('self') ;/
+    end
+  end
+
+  describe "csp directive 'style-src'" do
+    test "allows only self in prod",
+         %{
+           conn: conn,
+           brainstorming: brainstorming
+         } do
+      conn_response = get(conn, Routes.brainstorming_show_path(conn, :show, brainstorming))
+
+      assert conn_response
+             |> get_resp_header("content-security-policy")
+             |> List.first() =~ ~r/(style-src)\s+('self') ;/
     end
   end
 end


### PR DESCRIPTION
## Further Notes

- The use of script-src: unsafe-eval, as well as style-src: unsafe-inline is dangerous. Therefore, we'll disallow it in the CSP for all other environments except development.

## New Features / Enhancements

- Harden CSP Policy

## After Merge Checklist

- [x] Test CSP
