### PR TITLE
design: improve mobile layout #284

### DIFF
--- a/lib/mindwendel_web/live/brainstorming_live/show.html.heex
+++ b/lib/mindwendel_web/live/brainstorming_live/show.html.heex
@@ -20,41 +20,38 @@
       <div class="col-sm-12 col-md-12 col-xl-6">
         <h2 id="brainstorming-title"><%= @brainstorming.name %></h2>
       </div>
-      <div class="col-sm-12 col-md-12 col-xl-6">
-        <div class="d-grid d-md-flex justify-content-md-end">
-          <%= live_patch(gettext("New Idea"),
-            to: Routes.brainstorming_show_path(@socket, :new_idea, @brainstorming),
-            class: "btn btn-primary m-1",
-            title: gettext("New idea page (Hotkey: i)")
-          ) %>
-          <%= link to: "#", class: "btn btn-primary m-1", phx_click: "sort_by_likes", phx_value_id: @brainstorming.id, title: gettext("Sort by likes") do %>
-            <i class="bi-sort-numeric-up-alt"></i> <%= gettext("Sort by likes") %>
-          <% end %>
-          <%= link to: "#", class: "btn btn-primary m-1", phx_click: "sort_by_label", phx_value_id: @brainstorming.id, title: gettext("Sort by label") do %>
-            <i class="bi-sort-alpha-up-alt"></i> <%= gettext("Sort by label") %>
-          <% end %>
-        </div>
-        <div class="d-flex justify-content-end">
-          <%= live_patch to: Routes.brainstorming_show_path(@socket, :share, @brainstorming), class: "btn btn-secondary m-1", title: gettext("Share") do %>
-            <i class="bi-share-fill"></i> <%= gettext("Share") %>
-          <% end %>
+    </div>
+    <div class="d-flex justify-content-end flex-wrap">
+      <%= live_patch(gettext("New Idea"),
+        to: Routes.brainstorming_show_path(@socket, :new_idea, @brainstorming),
+        class: "btn btn-primary m-1 d-none d-md-block",
+        title: gettext("New idea page (Hotkey: i)")
+      ) %>
+      <%= link to: "#", class: "btn btn-primary m-1", phx_click: "sort_by_likes", phx_value_id: @brainstorming.id, title: gettext("Sort by likes") do %>
+        <i class="bi-sort-numeric-up-alt"></i> <%= gettext("Likes") %>
+      <% end %>
+      <%= link to: "#", class: "btn btn-primary m-1", phx_click: "sort_by_label", phx_value_id: @brainstorming.id, title: gettext("Sort by label") do %>
+        <i class="bi-sort-alpha-up-alt"></i> <%= gettext("Label") %>
+      <% end %>
 
-          <%= if @brainstorming.option_show_link_to_settings do %>
-            <%= link to: Routes.admin_brainstorming_edit_path(@socket, :edit, @brainstorming.admin_url_id), class: "btn btn-secondary m-1" do %>
-              <i class="bi-gear-fill"></i>
-            <% end %>
-          <% end %>
+      <%= live_patch to: Routes.brainstorming_show_path(@socket, :share, @brainstorming), class: "btn btn-secondary m-1", title: gettext("Share") do %>
+        <i class="bi-share-fill"></i>
+      <% end %>
 
-          <div
-            class="deletion-date-hint btn btn-outline-secondary m-1"
-            data-bs-toggle="tooltip"
-            data-bs-placement="auto"
-            data-bs-custom-class="deletion-date-hint-tooltip"
-            data-bs-title={brainstorming_available_until_full_text(@brainstorming)}
-          >
-            <i class="bi-calendar-x"></i> <%= brainstorming_available_until(@brainstorming) %>
-          </div>
-        </div>
+      <%= if @brainstorming.option_show_link_to_settings do %>
+        <%= link to: Routes.admin_brainstorming_edit_path(@socket, :edit, @brainstorming.admin_url_id), class: "btn btn-secondary m-1" do %>
+          <i class="bi-gear-fill"></i>
+        <% end %>
+      <% end %>
+
+      <div
+        class="deletion-date-hint btn btn-outline-secondary m-1"
+        data-bs-toggle="tooltip"
+        data-bs-placement="auto"
+        data-bs-custom-class="deletion-date-hint-tooltip"
+        data-bs-title={brainstorming_available_until_full_text(@brainstorming)}
+      >
+        <i class="bi-calendar-x"></i> <%= brainstorming_available_until(@brainstorming) %>
       </div>
     </div>
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -98,7 +98,7 @@ msgid "Idea created successfully"
 msgstr "Idee erstellt"
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:25
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:122
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "New Idea"
 msgstr "Neue Idee"
@@ -108,7 +108,7 @@ msgstr "Neue Idee"
 msgid "New brainstorming"
 msgstr "Neues Brainstorming"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:74
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "New idea"
 msgstr "Neue Idee"
@@ -123,7 +123,7 @@ msgstr "Neue Idee (Hotkey: i)"
 msgid "No ideas brainstormed"
 msgstr "Bisher keine Ideen"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:125
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Open new idea page (Hotkey: i)"
 msgstr "Öffne neue Ideen Dialog (Hotkey: i)"
@@ -149,13 +149,11 @@ msgid "Saving..."
 msgstr "Speichere..."
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:33
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Sort by label"
 msgstr "Sortiere nach Label"
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:30
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Sort by likes"
 msgstr "Sortiere nach Likes"
@@ -322,13 +320,12 @@ msgstr "Trete meinem Brainstorming bei."
 msgid "Mindwendel Brainstorming"
 msgstr "Mindwendel Brainstorming"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:38
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:39
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr "Teilen"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:98
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Share brainstorming"
 msgstr "Teile Dein Brainstorming"
@@ -358,7 +355,7 @@ msgstr ""
 msgid "Idea created updated"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:86
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Update idea"
 msgstr ""
@@ -383,3 +380,13 @@ msgstr "Bist du sicher, dass das Brainstorming geleert werden soll?"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Empty brainstorming"
 msgstr "Leere das Brainstorming"
+
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "Label"
+msgstr "Label"
+
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "Likes"
+msgstr "Likes"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -97,7 +97,7 @@ msgid "Idea created successfully"
 msgstr ""
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:25
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:122
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "New Idea"
 msgstr ""
@@ -107,7 +107,7 @@ msgstr ""
 msgid "New brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:74
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "New idea"
 msgstr ""
@@ -122,7 +122,7 @@ msgstr ""
 msgid "No ideas brainstormed"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:125
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Open new idea page (Hotkey: i)"
 msgstr ""
@@ -148,13 +148,11 @@ msgid "Saving..."
 msgstr ""
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:33
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Sort by label"
 msgstr ""
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:30
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Sort by likes"
 msgstr ""
@@ -321,13 +319,12 @@ msgstr ""
 msgid "Mindwendel Brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:38
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:39
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:98
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Share brainstorming"
 msgstr ""
@@ -357,7 +354,7 @@ msgstr ""
 msgid "Idea created updated"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:86
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Update idea"
 msgstr ""
@@ -381,4 +378,14 @@ msgstr ""
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Empty brainstorming"
+msgstr ""
+
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "Label"
+msgstr ""
+
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "Likes"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -98,7 +98,7 @@ msgid "Idea created successfully"
 msgstr ""
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:25
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:122
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "New Idea"
 msgstr ""
@@ -108,7 +108,7 @@ msgstr ""
 msgid "New brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:74
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "New idea"
 msgstr ""
@@ -123,7 +123,7 @@ msgstr ""
 msgid "No ideas brainstormed"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:125
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Open new idea page (Hotkey: i)"
 msgstr ""
@@ -149,13 +149,11 @@ msgid "Saving..."
 msgstr ""
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:33
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Sort by label"
 msgstr ""
 
 #: lib/mindwendel_web/live/brainstorming_live/show.html.heex:30
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Sort by likes"
 msgstr ""
@@ -322,13 +320,12 @@ msgstr "Join my brainstorming"
 msgid "Mindwendel Brainstorming"
 msgstr "Mindwendel Brainstorming"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:38
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:39
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr "Share"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:98
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "Share brainstorming"
 msgstr "Share brainstorming"
@@ -358,7 +355,7 @@ msgstr ""
 msgid "Idea created updated"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:86
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Update idea"
 msgstr ""
@@ -382,4 +379,14 @@ msgstr "Are you sure that you want to delete this brainstorming?"
 #: lib/mindwendel_web/live/admin/brainstorming_live/edit.html.heex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Empty brainstorming"
+msgstr ""
+
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "Label"
+msgstr ""
+
+#: lib/mindwendel_web/live/brainstorming_live/show.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "Likes"
 msgstr ""


### PR DESCRIPTION
## Further Notes

Reduces clutter in mobile view. Close #284 

## After Merge Checklist

- [x] Removes new item from upper toolbar for small screens - button at the bottom of the screen is sufficient.
- [x] Moves layout to one row by default, or two rows for smaller screens
