### PR TITLE
Move mentions of docker-compose to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,22 +65,22 @@ mindwendel is built on top of:
 
 ### Development
 
-- Startup docker-compose setup
+- Startup docker compose setup
 
   ```bash
-  docker-compose up --build -d
+  docker compose up --build -d
   ```
 
 - Setup the database
 
   ```bash
-  docker-compose exec app mix ecto.setup
+  docker compose exec app mix ecto.setup
   ```
 
 - Start the server
 
 ```bash
-  docker-compose exec app mix phx.server
+  docker compose exec app mix phx.server
 ```
 
 - Go to http://localhost:4000/
@@ -90,29 +90,29 @@ mindwendel is built on top of:
 - Open a shell in the docker container to execute tests, etc.
 
   ```bash
-  docker-compose exec app sh
+  docker compose exec app sh
   ```
 
 - Go to http://localhost:4000/
 
 ### Testing
 
-- Startup docker-compose setup
+- Startup docker compose setup
 
   ```bash
-  docker-compose up --build -d
+  docker compose up --build -d
   ```
 
 - Ensure your database is running and reset your database
 
   ```bash
-  docker-compose exec app mix ecto.test.prepare
+  docker compose exec app mix ecto.test.prepare
   ```
 
 - Run the test
 
   ```bash
-  docker-compose exec app mix test
+  docker compose exec app mix test
   ```
 
 ### Production
@@ -139,7 +139,7 @@ mindwendel is built on top of:
 - Start everything at once (including a forced build):
 
   ```bash
-  docker-compose --file docker-compose-prod.yml --env-file .env.prod up -d --build --force-recreate
+  docker compose --file docker-compose-prod.yml --env-file .env.prod up -d --build --force-recreate
   ```
 
 - Open the browser and go to `http://${URL_HOST}`

--- a/docs/installing_mindwendel.md
+++ b/docs/installing_mindwendel.md
@@ -9,7 +9,7 @@ Below, we provide detailed instructions on how to install and run mindwendel in 
 
 ## Running on Docker-Compose
 
-When you use [docker-compose](https://docs.docker.com/compose/), you will be using one or several `docker-compose.yml` files.
+When you use [docker compose](https://docs.docker.com/compose/), you will be using one or several `docker-compose.yml` files.
 
 - Add the following snippets to one of your `docker-compose.yml` file
 
@@ -75,7 +75,7 @@ When you use [docker-compose](https://docs.docker.com/compose/), you will be usi
 - To run mindwendel via Docker-Compose, just type
 
   ```sh
-  docker-compose up
+  docker compose up
   ```
 
 - To create the production database (after having created the containers via up):


### PR DESCRIPTION
`docker-compose` is v1, `docker compose` is v2 - v1 doesn't see updates any more. v2 also ships by default with docker (as best as I can tell).

https://docs.docker.com/compose/migrate/
