### PR TITLE
Readme: use bash instead of sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ mindwendel is built on top of:
 - Open a shell in the docker container to execute tests, etc.
 
   ```bash
-  docker compose exec app sh
+  docker compose exec app bash
   ```
 
 - Go to http://localhost:4000/


### PR DESCRIPTION
Because the docs said so I used `sh` and I couldn't get back last commands or even use the arrows to navigate on the same line to fix spelling. Using `bash` solved the issue.