### PR TITLE
Introduce .iex.exs

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,2 @@
+alias Mindwendel.Repo
+alias Mindwendel.Brainstormings.Brainstorming


### PR DESCRIPTION
The file is automatically loaded when running `iex` - it's intended to avoid writing a bunch of aliases in `iex -S mix` every time an session is launched. As such, it's immensely helpful generally. :)