### PR TITLE
Remove unnecesary relationship declarations in schemas

### DIFF
--- a/lib/mindwendel/accounts/brainstorming_user.ex
+++ b/lib/mindwendel/accounts/brainstorming_user.ex
@@ -4,8 +4,8 @@ defmodule Mindwendel.Accounts.BrainstormingUser do
   alias Mindwendel.Accounts.User
 
   schema "brainstorming_users" do
-    belongs_to :brainstorming, Brainstorming, foreign_key: :brainstorming_id, type: :binary_id
-    belongs_to :user, User, foreign_key: :user_id, type: :binary_id
+    belongs_to :brainstorming, Brainstorming
+    belongs_to :user, User
 
     timestamps()
   end

--- a/lib/mindwendel/attachments/link.ex
+++ b/lib/mindwendel/attachments/link.ex
@@ -8,7 +8,7 @@ defmodule Mindwendel.Attachments.Link do
     field :title, :string
     field :description, :string
     field :img_preview_url, :string
-    belongs_to :idea, Idea, type: :binary_id
+    belongs_to :idea, Idea
 
     timestamps()
   end

--- a/lib/mindwendel/brainstormings/brainstorming_moderating_user.ex
+++ b/lib/mindwendel/brainstormings/brainstorming_moderating_user.ex
@@ -1,4 +1,5 @@
 defmodule Mindwendel.Brainstormings.BrainstormingModeratingUser do
+  # Not using Mindwendel.Schema as the `@derive` in there clashes here
   use Ecto.Schema
   alias Mindwendel.Brainstormings.Brainstorming
   alias Mindwendel.Accounts.User

--- a/lib/mindwendel/brainstormings/idea.ex
+++ b/lib/mindwendel/brainstormings/idea.ex
@@ -21,9 +21,9 @@ defmodule Mindwendel.Brainstormings.Idea do
     has_one :link, Link
     belongs_to :user, User
     has_many :likes, Like
-    belongs_to :brainstorming, Brainstorming, foreign_key: :brainstorming_id, type: :binary_id
-    belongs_to :label, IdeaLabel, foreign_key: :label_id, type: :binary_id, on_replace: :nilify
-    belongs_to :lane, Lane, foreign_key: :lane_id, type: :binary_id
+    belongs_to :brainstorming, Brainstorming
+    belongs_to :label, IdeaLabel, on_replace: :nilify
+    belongs_to :lane, Lane
     many_to_many :idea_labels, IdeaLabel, join_through: IdeaIdeaLabel, on_replace: :delete
 
     timestamps()

--- a/lib/mindwendel/brainstormings/idea_idea_label.ex
+++ b/lib/mindwendel/brainstormings/idea_idea_label.ex
@@ -1,4 +1,5 @@
 defmodule Mindwendel.Brainstormings.IdeaIdeaLabel do
+  # doesn't use `Mindwendel.Schema` as the default `@derive` there intereferes here
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/mindwendel/brainstormings/idea_label.ex
+++ b/lib/mindwendel/brainstormings/idea_label.ex
@@ -13,7 +13,7 @@ defmodule Mindwendel.Brainstormings.IdeaLabel do
     # See https://hexdocs.pm/ecto/Ecto.Changeset.html#module-the-on_replace-option
     field :delete, :boolean, virtual: true
 
-    belongs_to :brainstorming, Brainstorming, foreign_key: :brainstorming_id, type: :binary_id
+    belongs_to :brainstorming, Brainstorming
 
     many_to_many :ideas, Idea, join_through: "idea_idea_labels", on_replace: :delete
     has_many :idea_idea_labels, IdeaIdeaLabel, on_replace: :delete

--- a/lib/mindwendel/brainstormings/lane.ex
+++ b/lib/mindwendel/brainstormings/lane.ex
@@ -9,7 +9,7 @@ defmodule Mindwendel.Brainstormings.Lane do
   schema "lanes" do
     field :name, :string
     field :position_order, :integer
-    belongs_to :brainstorming, Brainstorming, type: :binary_id
+    belongs_to :brainstorming, Brainstorming
     has_many :ideas, Idea, preload_order: [asc: :position_order, asc: :inserted_at]
 
     timestamps()

--- a/lib/mindwendel/brainstormings/like.ex
+++ b/lib/mindwendel/brainstormings/like.ex
@@ -6,8 +6,8 @@ defmodule Mindwendel.Brainstormings.Like do
   alias Mindwendel.Accounts.User
 
   schema "likes" do
-    belongs_to :idea, Idea, type: :binary_id
-    belongs_to :user, User, type: :binary_id
+    belongs_to :idea, Idea
+    belongs_to :user, User
 
     timestamps()
   end


### PR DESCRIPTION
* the name of the foreign key is usually infered based on naming
* the type is already per default defined in the `Mindwendel.Schema`
* I think it was a mixture of not migrating old code to match the new after it was changed

## Further Notes

On a side note, can't be applied to the join table as `Mindwendel.Schema` comes with `@derive {Phoenix.Param, key: :id}` where I'm not sure that's a good default/needed for all the schemas and hence might be better off being selectively added.

However, I don't know the code well enough to make that call, so I left it as is.
