### PR TITLE
Include a default key in .env.default

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -16,10 +16,11 @@ DOCKER_COMPOSE_APP_MW_FEATURE_STORAGE_PROVIDER=local
 DOCKER_COMPOSE_APP_MW_FEATURE_IDEA_FILE_UPLOAD=true
 DOCKER_COMPOSE_APP_OBJECT_STORAGE_USER=
 DOCKER_COMPOSE_APP_OBJECT_STORAGE_PASSWORD=
+# This is an example key. Do not use in production!
 # please generate a secure key before, e.g. by using the elixir console inside the container:
 # iex
 # iex> 32 |> :crypto.strong_rand_bytes() |> Base.encode64()
-DOCKER_COMPOSE_APP_VAULT_ENCRYPTION_KEY_BASE64=
+DOCKER_COMPOSE_APP_VAULT_ENCRYPTION_KEY_BASE64="gI6L07o3RTppqy+cfAxO4C8G8psYHWn2NYPbUymYI1o="
 # This is an example secret key base that can be use in development
 # NOTE: There are multiple commands you can use to generate a secret key base. Pick one command you like, e.g. `date +%s | sha256sum | base64 | head -c 64 ; echo`
 # !!ATTENTION: DO NOT USE THIS FOR PRODUCTION!!


### PR DESCRIPTION
Better default dev experience, we also already include another secret key base in there (I think we should either include examples/ test values for all or none).
