### PR TITLE
Remove initial check mark from inputs

### DIFF
--- a/lib/mindwendel_web/components/core_components.ex
+++ b/lib/mindwendel_web/components/core_components.ex
@@ -384,8 +384,7 @@ defmodule MindwendelWeb.CoreComponents do
         name={@name}
         class={[
           "form-control",
-          @used? && @errors == [] && "is-valid",
-          @used? && @errors != [] && "is-invalid"
+          error_class(@used?, @errors)
         ]}
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
@@ -403,8 +402,7 @@ defmodule MindwendelWeb.CoreComponents do
       value={Phoenix.HTML.Form.normalize_value(@type, @value)}
       class={[
         "form-control",
-        @used? && @errors == [] && "is-valid",
-        @used? && @errors != [] && "is-invalid"
+        error_class(@used?, @errors)
       ]}
       {@rest}
     />
@@ -423,8 +421,7 @@ defmodule MindwendelWeb.CoreComponents do
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
           "form-control",
-          @used? && @errors == [] && "is-valid",
-          @used? && @errors != [] && "is-invalid"
+          error_class(@used?, @errors)
         ]}
         {@rest}
       />
@@ -432,6 +429,11 @@ defmodule MindwendelWeb.CoreComponents do
     </div>
     """
   end
+
+  defp error_class(used?, errors)
+  defp error_class(false, _errors), do: nil
+  defp error_class(true, []), do: "is-valid"
+  defp error_class(_true, _non_empty), do: "is-invalid"
 
   @doc """
   Renders a label.

--- a/lib/mindwendel_web/components/core_components.ex
+++ b/lib/mindwendel_web/components/core_components.ex
@@ -291,12 +291,16 @@ defmodule MindwendelWeb.CoreComponents do
     include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)
 
+  attr :used?, :boolean, doc: "This field was actually used (set by compoenent itself)"
+
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-    errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+    used? = Phoenix.Component.used_input?(field)
+    errors = if used?, do: field.errors, else: []
 
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
     |> assign(:errors, Enum.map(errors, &translate_error(&1)))
+    |> assign(:used?, used?)
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> input()
@@ -380,8 +384,8 @@ defmodule MindwendelWeb.CoreComponents do
         name={@name}
         class={[
           "form-control",
-          @errors == [] && "is-valid",
-          @errors != [] && "is-invalid"
+          @used? && @errors == [] && "is-valid",
+          @used? && @errors != [] && "is-invalid"
         ]}
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
@@ -399,8 +403,8 @@ defmodule MindwendelWeb.CoreComponents do
       value={Phoenix.HTML.Form.normalize_value(@type, @value)}
       class={[
         "form-control",
-        @errors == [] && "is-valid",
-        @errors != [] && "is-invalid"
+        @used? && @errors == [] && "is-valid",
+        @used? && @errors != [] && "is-invalid"
       ]}
       {@rest}
     />
@@ -419,8 +423,8 @@ defmodule MindwendelWeb.CoreComponents do
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
           "form-control",
-          @errors == [] && "is-valid",
-          @errors != [] && "is-invalid"
+          @used? && @errors == [] && "is-valid",
+          @used? && @errors != [] && "is-invalid"
         ]}
         {@rest}
       />

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -327,7 +327,7 @@ msgstr "Nutzern das Verschieben und Sortieren von Ideen erlauben"
 msgid "Back"
 msgstr "Zurück"
 
-#: lib/mindwendel_web/components/core_components.ex:522
+#: lib/mindwendel_web/components/core_components.ex:528
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: lib/mindwendel_web/components/core_components.ex:522
+#: lib/mindwendel_web/components/core_components.ex:528
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -327,7 +327,7 @@ msgstr "Allow users to change the order of ideas"
 msgid "Back"
 msgstr ""
 
-#: lib/mindwendel_web/components/core_components.ex:522
+#: lib/mindwendel_web/components/core_components.ex:528
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""


### PR DESCRIPTION
This almost lost me my entire mind as it'd silently swallow the `used?` attribute and so nothing would work until I figured out it needed to be added there. No debug no nothing... just what seemed like a normal function call completely swallowing part of its argument. I hate magic.

![Peek 2024-11-24 11-39](https://github.com/user-attachments/assets/719022fe-6bf0-4409-85d9-af5319ba1dbb)
