### PR TITLE
Introduce Feature flags as a concept

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -52,13 +52,6 @@ config :mindwendel, MindwendelWeb.Endpoint,
 # Do not print debug messages in production
 config :logger, level: :info
 
-config :mindwendel, :options,
-  feature_brainstorming_teasers:
-    Enum.member?(
-      ["", "true"],
-      String.trim(System.get_env("MW_FEATURE_BRAINSTORMING_TEASER") || "")
-    )
-
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/lib/mindwendel/attachments/file.ex
+++ b/lib/mindwendel/attachments/file.ex
@@ -2,6 +2,7 @@ defmodule Mindwendel.Attachments.File do
   use Mindwendel.Schema
   import Ecto.Changeset
   alias Mindwendel.Brainstormings.Idea
+  alias Mindwendel.FeatureFlag
   alias Mindwendel.Services.StorageService
 
   schema "idea_files" do
@@ -23,9 +24,7 @@ defmodule Mindwendel.Attachments.File do
   end
 
   defp maybe_store_from_path_tmp(changeset) do
-    upload_feature_flag = Application.fetch_env!(:mindwendel, :options)[:feature_file_upload]
-
-    if upload_feature_flag and get_change(changeset, :path) do
+    if FeatureFlag.enabled?(:feature_file_upload) and get_change(changeset, :path) do
       object_filename = Path.basename(get_change(changeset, :path))
 
       {:ok, encrypted_file_path} =

--- a/lib/mindwendel/brainstormings/idea.ex
+++ b/lib/mindwendel/brainstormings/idea.ex
@@ -8,6 +8,7 @@ defmodule Mindwendel.Brainstormings.Idea do
   alias Mindwendel.Brainstormings.Like
   alias Mindwendel.Brainstormings.Lane
   alias Mindwendel.Brainstormings.Comment
+  alias Mindwendel.FeatureFlag
   alias Mindwendel.Ideas
   alias Mindwendel.Attachments
   alias Mindwendel.Attachments.Link
@@ -75,9 +76,7 @@ defmodule Mindwendel.Brainstormings.Idea do
   end
 
   defp maybe_put_attachments(changeset, idea, attrs) do
-    upload_feature_flag = Application.fetch_env!(:mindwendel, :options)[:feature_file_upload]
-
-    if upload_feature_flag and
+    if FeatureFlag.enabled?(:feature_file_upload) and
          attrs["tmp_attachments"] != nil and Enum.empty?(changeset.errors) do
       new_files =
         Enum.map(attrs["tmp_attachments"], fn change ->

--- a/lib/mindwendel/feature_flag.ex
+++ b/lib/mindwendel/feature_flag.ex
@@ -1,0 +1,14 @@
+defmodule Mindwendel.FeatureFlag do
+  @moduledoc """
+  Support for checking feature flags.
+
+  Feature flags are defined under the `:options` key for `:mindwendel` in the config.
+  If a flag isn't set it is treated as deactivated.
+  """
+
+  def enabled?(flag_name) do
+    :mindwendel
+    |> Application.fetch_env!(:options)
+    |> Access.get(flag_name)
+  end
+end

--- a/lib/mindwendel/help.ex
+++ b/lib/mindwendel/help.ex
@@ -4,13 +4,10 @@ defmodule Mindwendel.Help do
   """
 
   import Ecto.Query, warn: false
-  alias Mindwendel.FeatureFlag
   alias Mindwendel.Repo
   alias Mindwendel.Help.Inspiration
 
   def random_inspiration do
-    if FeatureFlag.enabled?(:feature_brainstorming_teasers) do
-      Repo.one(from t in Inspiration, order_by: fragment("RANDOM()"), limit: 1)
-    end
+    Repo.one(from t in Inspiration, order_by: fragment("RANDOM()"), limit: 1)
   end
 end

--- a/lib/mindwendel/help.ex
+++ b/lib/mindwendel/help.ex
@@ -4,11 +4,12 @@ defmodule Mindwendel.Help do
   """
 
   import Ecto.Query, warn: false
+  alias Mindwendel.FeatureFlag
   alias Mindwendel.Repo
   alias Mindwendel.Help.Inspiration
 
   def random_inspiration do
-    if Application.fetch_env!(:mindwendel, :options)[:feature_brainstorming_teasers] do
+    if FeatureFlag.enabled?(:feature_brainstorming_teasers) do
       Repo.one(from t in Inspiration, order_by: fragment("RANDOM()"), limit: 1)
     end
   end

--- a/lib/mindwendel_web/controllers/static_page_controller.ex
+++ b/lib/mindwendel_web/controllers/static_page_controller.ex
@@ -2,6 +2,7 @@ defmodule MindwendelWeb.StaticPageController do
   use MindwendelWeb, :controller
   alias Mindwendel.Brainstormings
   alias Mindwendel.Brainstormings.Brainstorming
+  alias Mindwendel.FeatureFlag
 
   plug :put_root_layout, {MindwendelWeb.Layouts, :static_page}
 
@@ -23,7 +24,7 @@ defmodule MindwendelWeb.StaticPageController do
   end
 
   def legal(conn, _params) do
-    if Application.fetch_env!(:mindwendel, :options)[:feature_privacy_imprint_enabled] do
+    if FeatureFlag.enabled?(:feature_privacy_imprint_enabled) do
       render(conn, "legal.html")
     else
       render_404(conn)
@@ -31,7 +32,7 @@ defmodule MindwendelWeb.StaticPageController do
   end
 
   def privacy(conn, _params) do
-    if Application.fetch_env!(:mindwendel, :options)[:feature_privacy_imprint_enabled] do
+    if FeatureFlag.enabled?(:feature_privacy_imprint_enabled) do
       render(conn, "privacy.html")
     else
       render_404(conn)

--- a/lib/mindwendel_web/controllers/static_page_html/home.html.heex
+++ b/lib/mindwendel_web/controllers/static_page_html/home.html.heex
@@ -70,7 +70,7 @@
   </main>
   <footer class="mt-auto">
     <span class="me-2">Made with ❤️ in the 🇪🇺</span>
-    <%= if Application.fetch_env!(:mindwendel, :options)[:feature_privacy_imprint_enabled] do %>
+    <%= if Mindwendel.FeatureFlag.enabled?(:feature_privacy_imprint_enabled) do %>
       <br class="d-md-none" />
       <.link href={~p"/legal"}><%= gettext("Legal Disclosure") %></.link>
       | <.link href={~p"/privacy"}><%= gettext("Privacy") %></.link>

--- a/lib/mindwendel_web/live/brainstorming_live/show.ex
+++ b/lib/mindwendel_web/live/brainstorming_live/show.ex
@@ -3,6 +3,7 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
 
   alias Mindwendel.Accounts
   alias Mindwendel.Brainstormings
+  alias Mindwendel.FeatureFlag
   alias Mindwendel.Lanes
   alias Mindwendel.Ideas
   alias Mindwendel.Brainstormings.Idea
@@ -34,7 +35,7 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
       |> assign(:brainstorming, brainstorming)
       |> assign(:lanes, lanes)
       |> assign(:current_user, current_user)
-      |> assign(:inspiration, Mindwendel.Help.random_inspiration())
+      |> assign(:inspiration, inspiration())
     }
   end
 
@@ -178,5 +179,11 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
   defp apply_action(socket, :share, _params) do
     socket
     |> assign(:page_title, socket.assigns.brainstorming.name)
+  end
+
+  defp inspiration do
+    if FeatureFlag.enabled?(:feature_brainstorming_teasers) do
+      Mindwendel.Help.random_inspiration()
+    end
   end
 end

--- a/lib/mindwendel_web/live/idea_live/form_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/form_component.html.heex
@@ -8,7 +8,7 @@
   >
     <.input field={@form[:username]} type="text" label={gettext("Username")} phx-debounce={300} />
     <.input field={@form[:body]} type="textarea" label={gettext("Your idea")} phx-debounce={300} />
-    <%= if show_idea_file_upload() do %>
+    <%= if show_idea_file_upload?() do %>
       <div class="form-group">
         <.label for={@uploads.attachment.ref}><%= gettext("Additional Attachment") %></.label>
         <.live_file_input upload={@uploads.attachment} class="w-100" />

--- a/lib/mindwendel_web/live/live_helpers.ex
+++ b/lib/mindwendel_web/live/live_helpers.ex
@@ -2,6 +2,7 @@ defmodule MindwendelWeb.LiveHelpers do
   use Gettext, backend: MindwendelWeb.Gettext
 
   alias Mindwendel.Brainstormings.Brainstorming
+  alias Mindwendel.FeatureFlag
 
   def has_move_permission(brainstorming, current_user) do
     brainstorming.option_allow_manual_ordering or
@@ -36,6 +37,6 @@ defmodule MindwendelWeb.LiveHelpers do
   end
 
   def show_idea_file_upload do
-    Application.fetch_env!(:mindwendel, :options)[:feature_file_upload]
+    FeatureFlag.enabled?(:feature_file_upload)
   end
 end

--- a/lib/mindwendel_web/live/live_helpers.ex
+++ b/lib/mindwendel_web/live/live_helpers.ex
@@ -36,7 +36,7 @@ defmodule MindwendelWeb.LiveHelpers do
     Brainstorming.brainstorming_available_until(brainstorming)
   end
 
-  def show_idea_file_upload do
+  def show_idea_file_upload? do
     FeatureFlag.enabled?(:feature_file_upload)
   end
 end

--- a/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
+++ b/lib/mindwendel_web/plugs/set_response_header_content_security_policy.ex
@@ -1,6 +1,8 @@
 defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
   @content_secrity_policy_response_header_key "content-security-policy"
 
+  alias Mindwendel.FeatureFlag
+
   # @impl true
   def init(opts) do
     opts
@@ -50,13 +52,13 @@ defmodule Mindwendel.Plugs.SetResponseHeaderContentSecurityPolicy do
   end
 
   def get_script_src() do
-    if Application.fetch_env!(:mindwendel, :options)[:csp_relax],
+    if FeatureFlag.enabled?(:csp_relax),
       do: "'self' 'unsafe-eval'",
       else: "'self'"
   end
 
   def get_style_src() do
-    if Application.fetch_env!(:mindwendel, :options)[:csp_relax],
+    if FeatureFlag.enabled?(:csp_relax),
       do: "'self' 'unsafe-inline'",
       else: "'self'"
   end

--- a/lib/mindwendel_web/templates/layout/root.html.heex
+++ b/lib/mindwendel_web/templates/layout/root.html.heex
@@ -77,7 +77,7 @@
                 </ul>
               </li>
 
-              <%= if Application.fetch_env!(:mindwendel, :options)[:feature_privacy_imprint_enabled] do %>
+              <%= if Mindwendel.FeatureFlag.enabled?(:feature_privacy_imprint_enabled) do %>
                 <li aria-current="page" class="nav-item">
                   <.link href={~p"/privacy"} class="nav-link"><%= gettext("Privacy") %></.link>
                 </li>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -25,12 +25,12 @@ msgstr ""
 msgid "Ready?"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:175
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:152
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:153
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr ""
@@ -298,7 +298,7 @@ msgstr ""
 msgid "Empty brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/live_helpers.ex:29
+#: lib/mindwendel_web/live/live_helpers.ex:30
 #, elixir-autogen, elixir-format
 msgid "Brainstorming will be deleted %{days}"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:162
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:163
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Lane"
 msgstr ""


### PR DESCRIPTION
This should fix #480 

* the first commit adds the feature flag context/helper
* the latter 2 commits do some really light work that you may decide you may not want (number 3 in particular has some reasoning for it inside the commit but it's a taste thing, mostly :shrug: )

Other thinking:
* the `options` key seemingly has feature flags and some full on options mixed with each other, instead of pre-fixing keys `feature` (and one post-fixed _enabled_) I think I'd put them into a sub-key (of options) `feature_flags: [_flags_]` but I don't know if we need to keep backwards compatibility here (not change the names, do people adjust this themselves or do they go via system envs?)
* There is another feature/feature flag that is named `feature_brainstorming_removal_after_days` and holds a number of days, not a boolean - maybe we want to have this implementation as a more general `Options` module that then also has a function like `get` that just gets that option value? I'm unsure and would need input!