### PR TITLE
Performance improvements: Add Brainstorming Label to idea + broadcast lane update

### DIFF
--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -98,6 +98,10 @@ defmodule Mindwendel.Brainstormings do
     end
   end
 
+  def get_bare_brainstorming!(id) do
+    Repo.get!(Brainstorming, id)
+  end
+
   @doc """
   Gets a single brainstorming with the admin url id
   """

--- a/lib/mindwendel/brainstormings/idea_idea_label.ex
+++ b/lib/mindwendel/brainstormings/idea_idea_label.ex
@@ -24,4 +24,13 @@ defmodule Mindwendel.Brainstormings.IdeaIdeaLabel do
       name: :idea_idea_labels_idea_id_idea_label_id_index
     )
   end
+
+  def bare_creation_changeset(idea_idea_label \\ %__MODULE__{}, attrs) do
+    idea_idea_label
+    |> cast(attrs, [:idea_id, :idea_label_id])
+    |> validate_required([:idea_id, :idea_label_id])
+    |> unique_constraint([:idea_id, :idea_label_id],
+      name: :idea_idea_labels_idea_id_idea_label_id_index
+    )
+  end
 end

--- a/lib/mindwendel/idea_labels.ex
+++ b/lib/mindwendel/idea_labels.ex
@@ -28,18 +28,13 @@ defmodule Mindwendel.IdeaLabels do
     nil
   end
 
+  # As the broadcast results in a full reload of the ideas, we don't need to actually update
+  # the idea struct, a new association is enough
   def add_idea_label_to_idea(%Idea{} = idea, %IdeaLabel{} = idea_label) do
-    idea = Repo.preload(idea, :idea_labels)
-
-    idea_labels =
-      (idea.idea_labels ++ [idea_label])
-      |> Enum.map(&Ecto.Changeset.change/1)
-
     result =
-      idea
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_assoc(:idea_labels, idea_labels)
-      |> Repo.update()
+      %{idea_id: idea.id, idea_label_id: idea_label.id}
+      |> IdeaIdeaLabel.bare_creation_changeset()
+      |> Repo.insert()
 
     Lanes.broadcast_lanes_update(idea.brainstorming_id)
     result

--- a/lib/mindwendel/idea_labels.ex
+++ b/lib/mindwendel/idea_labels.ex
@@ -30,9 +30,9 @@ defmodule Mindwendel.IdeaLabels do
 
   # As the broadcast results in a full reload of the ideas, we don't need to actually update
   # the idea struct, a new association is enough
-  def add_idea_label_to_idea(%Idea{} = idea, %IdeaLabel{} = idea_label) do
+  def add_idea_label_to_idea(idea, idea_label_id) do
     result =
-      %{idea_id: idea.id, idea_label_id: idea_label.id}
+      %{idea_id: idea.id, idea_label_id: idea_label_id}
       |> IdeaIdeaLabel.bare_creation_changeset()
       |> Repo.insert()
 
@@ -40,12 +40,12 @@ defmodule Mindwendel.IdeaLabels do
     result
   end
 
-  def remove_idea_label_from_idea(%Idea{} = idea, %IdeaLabel{} = idea_label) do
+  def remove_idea_label_from_idea(%Idea{} = idea, idea_label_id) do
     result =
       from(idea_idea_label in IdeaIdeaLabel,
         where:
           idea_idea_label.idea_id == ^idea.id and
-            idea_idea_label.idea_label_id == ^idea_label.id
+            idea_idea_label.idea_label_id == ^idea_label_id
       )
       |> Repo.delete_all()
 

--- a/lib/mindwendel/lanes.ex
+++ b/lib/mindwendel/lanes.ex
@@ -72,10 +72,7 @@ defmodule Mindwendel.Lanes do
   def get_lanes_for_brainstorming_with_labels_filtered(id) do
     {:ok, brainstorming} = Brainstormings.get_brainstorming(id)
 
-    filter_label =
-      if length(brainstorming.filter_labels_ids) > 0,
-        do: %{filter_labels_ids: brainstorming.filter_labels_ids},
-        else: %{}
+    filter_label = %{filter_labels_ids: brainstorming.filter_labels_ids}
 
     get_lanes_for_brainstorming(id, filter_label)
   end
@@ -89,7 +86,7 @@ defmodule Mindwendel.Lanes do
       [%Lane{}, ...]
 
   """
-  def get_lanes_for_brainstorming(id, filters \\ %{}) do
+  def get_lanes_for_brainstorming(id, filters \\ %{filter_labels_ids: []}) do
     lane_query =
       from lane in Lane,
         where: lane.brainstorming_id == ^id,
@@ -105,6 +102,10 @@ defmodule Mindwendel.Lanes do
     |> Repo.preload(ideas: {ideas_advanced_query, [:link, :likes, :idea_labels, :files]})
   end
 
+  defp build_ideas_query_with_filter(%{filter_labels_ids: []}) do
+    from(idea in Idea)
+  end
+
   defp build_ideas_query_with_filter(%{filter_labels_ids: filter_labels_ids}) do
     distinct_ideas =
       from idea in Idea,
@@ -116,10 +117,6 @@ defmodule Mindwendel.Lanes do
     from(i in subquery(distinct_ideas),
       order_by: [asc: i.position_order]
     )
-  end
-
-  defp build_ideas_query_with_filter(%{} = _filters) do
-    from(idea in Idea)
   end
 
   @doc """

--- a/lib/mindwendel/repo.ex
+++ b/lib/mindwendel/repo.ex
@@ -2,4 +2,8 @@ defmodule Mindwendel.Repo do
   use Ecto.Repo,
     otp_app: :mindwendel,
     adapter: Ecto.Adapters.Postgres
+
+  def count(query) do
+    aggregate(query, :count)
+  end
 end

--- a/lib/mindwendel_web/live/idea_live/card_component.ex
+++ b/lib/mindwendel_web/live/idea_live/card_component.ex
@@ -6,8 +6,8 @@ defmodule MindwendelWeb.IdeaLive.CardComponent do
   alias Mindwendel.Likes
 
   @impl true
-  def handle_event("delete_idea", %{"id" => id}, socket) do
-    idea = Ideas.get_idea!(id)
+  def handle_event("delete_idea", _params, socket) do
+    idea = socket.assigns.idea
 
     %{current_user: current_user, brainstorming: brainstorming} = socket.assigns
 
@@ -19,14 +19,14 @@ defmodule MindwendelWeb.IdeaLive.CardComponent do
     {:noreply, socket}
   end
 
-  def handle_event("like", %{"id" => id}, socket) do
-    Likes.add_like(id, socket.assigns.current_user.id)
+  def handle_event("like", _params, socket) do
+    Likes.add_like(socket.assigns.idea.id, socket.assigns.current_user.id)
 
     {:noreply, socket}
   end
 
-  def handle_event("unlike", %{"id" => id}, socket) do
-    Likes.delete_like(id, socket.assigns.current_user.id)
+  def handle_event("unlike", _params, socket) do
+    Likes.delete_like(socket.assigns.idea.id, socket.assigns.current_user.id)
 
     {:noreply, socket}
   end

--- a/lib/mindwendel_web/live/idea_live/card_component.ex
+++ b/lib/mindwendel_web/live/idea_live/card_component.ex
@@ -34,30 +34,22 @@ defmodule MindwendelWeb.IdeaLive.CardComponent do
   def handle_event(
         "add_idea_label_to_idea",
         %{
-          "idea-id" => idea_id,
           "idea-label-id" => idea_label_id
         },
         socket
       ) do
-    idea = Ideas.get_idea!(idea_id)
-    idea_label = IdeaLabels.get_idea_label(idea_label_id)
-
-    IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+    IdeaLabels.add_idea_label_to_idea(socket.assigns.idea, idea_label_id)
     {:noreply, socket}
   end
 
   def handle_event(
         "remove_idea_label_from_idea",
         %{
-          "idea-id" => idea_id,
           "idea-label-id" => idea_label_id
         },
         socket
       ) do
-    idea = Ideas.get_idea!(idea_id)
-    idea_label = IdeaLabels.get_idea_label(idea_label_id)
-
-    IdeaLabels.remove_idea_label_from_idea(idea, idea_label)
+    IdeaLabels.remove_idea_label_from_idea(socket.assigns.idea, idea_label_id)
     {:noreply, socket}
   end
 end

--- a/lib/mindwendel_web/live/idea_live/card_component.ex
+++ b/lib/mindwendel_web/live/idea_live/card_component.ex
@@ -42,13 +42,8 @@ defmodule MindwendelWeb.IdeaLive.CardComponent do
     idea = Ideas.get_idea!(idea_id)
     idea_label = IdeaLabels.get_idea_label(idea_label_id)
 
-    case(IdeaLabels.add_idea_label_to_idea(idea, idea_label)) do
-      {:ok, _idea} ->
-        {:noreply, socket}
-
-      {:error, _changeset} ->
-        {:noreply, socket}
-    end
+    IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+    {:noreply, socket}
   end
 
   def handle_event(

--- a/lib/mindwendel_web/live/idea_live/card_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/card_component.html.heex
@@ -13,7 +13,6 @@
         class="float-end ms-3 mb-3"
         phx-click="delete_idea"
         phx-target={@myself}
-        phx-value-id={@idea.id}
         title={gettext("Delete idea")}
         data-confirm={gettext("Are you sure you want to delete this idea?")}
       >
@@ -143,11 +142,11 @@
       </span>
       <span class="me-1 text-dark">{length(@idea.likes)}</span>
       <%= if Mindwendel.Likes.exists_user_in_likes?(@idea.likes, @current_user.id) do %>
-        <.link phx-click="unlike" phx-target={@myself} phx-value-id={@idea.id} title="Unlike">
+        <.link phx-click="unlike" phx-target={@myself} title="Unlike">
           <i class="bi-star-fill"></i>
         </.link>
       <% else %>
-        <.link phx-click="like" phx-target={@myself} phx-value-id={@idea.id} title="Like">
+        <.link phx-click="like" phx-target={@myself} title="Like">
           <i class="bi-star"></i>
         </.link>
       <% end %>

--- a/lib/mindwendel_web/live/idea_live/card_component.html.heex
+++ b/lib/mindwendel_web/live/idea_live/card_component.html.heex
@@ -97,7 +97,6 @@
             data-testid={brainstorming_idea_label.id}
             phx-click="add_idea_label_to_idea"
             phx-target={@myself}
-            phx-value-idea-id={@idea.id}
             title={"Label #{brainstorming_idea_label.name}"}
             phx-value-idea-label-id={brainstorming_idea_label.id}
           >
@@ -116,7 +115,6 @@
             data-testid={brainstorming_idea_label.id}
             phx-click="remove_idea_label_from_idea"
             phx-target={@myself}
-            phx-value-idea-id={@idea.id}
             title={"Label #{brainstorming_idea_label.name}"}
             phx-value-idea-label-id={brainstorming_idea_label.id}
           >

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -36,7 +36,7 @@ msgid "%{name} - New Idea"
 msgstr ""
 
 #: lib/mindwendel_web/live/comment_live/show_component.html.heex:22
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:18
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete this idea?"
 msgstr ""
@@ -195,7 +195,7 @@ msgstr ""
 
 #: lib/mindwendel_web/controllers/admin/brainstorming_html/export.html.heex:3
 #: lib/mindwendel_web/live/comment_live/show_component.html.heex:40
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:85
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "By"
 msgstr ""
@@ -451,13 +451,13 @@ msgstr ""
 msgid "No lanes available"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:25
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Edit idea"
 msgstr ""
 
 #: lib/mindwendel_web/live/comment_live/show_component.html.heex:30
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:17
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Delete idea"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "Additional Attachment"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:75
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:74
 #: lib/mindwendel_web/live/idea_live/form_component.html.heex:43
 #: lib/mindwendel_web/live/idea_live/show_component.html.heex:27
 #, elixir-autogen, elixir-format
@@ -529,8 +529,8 @@ msgstr ""
 msgid "No comments available"
 msgstr ""
 
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:33
-#: lib/mindwendel_web/live/idea_live/card_component.html.heex:140
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:32
+#: lib/mindwendel_web/live/idea_live/card_component.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Show idea"
 msgstr ""

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -323,7 +323,7 @@ defmodule Mindwendel.BrainstormingsTest do
       like = Factory.insert!(:like, idea: idea)
 
       {:ok, _idea_idea_label} =
-        IdeaLabels.add_idea_label_to_idea(idea, Enum.at(brainstorming.labels, 0))
+        IdeaLabels.add_idea_label_to_idea(idea, Enum.at(brainstorming.labels, 0).id)
 
       idea = idea |> Repo.preload([:idea_labels])
 

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -322,7 +322,7 @@ defmodule Mindwendel.BrainstormingsTest do
 
       like = Factory.insert!(:like, idea: idea)
 
-      {:ok, idea} =
+      {:ok, _idea_idea_label} =
         IdeaLabels.add_idea_label_to_idea(idea, Enum.at(brainstorming.labels, 0))
 
       idea = idea |> Repo.preload([:idea_labels])

--- a/test/mindwendel/idea_labels_test.exs
+++ b/test/mindwendel/idea_labels_test.exs
@@ -18,14 +18,14 @@ defmodule Mindwendel.IdeaLabelsTest do
 
   describe "#add_idea_label_to_idea" do
     test "adds IdeaLabel to Idea", %{idea_label: idea_label, idea: idea} do
-      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
 
       assert [idea_label] == labels_of(idea)
       assert Repo.count(IdeaIdeaLabel) == 1
     end
 
     test "creates one IdeaIdeaLabel", %{idea_label: idea_label, idea: idea} do
-      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
 
       assert Repo.count(IdeaIdeaLabel) == 1
 
@@ -37,7 +37,7 @@ defmodule Mindwendel.IdeaLabelsTest do
     test "does not create additional IdeaLabel", %{idea_label: idea_label, idea: idea} do
       assert Repo.count(IdeaLabel) == 1
 
-      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
 
       assert Repo.count(IdeaLabel) == 1
       assert Repo.one(IdeaLabel) == idea_label
@@ -47,10 +47,10 @@ defmodule Mindwendel.IdeaLabelsTest do
     test "does not add the same IdeaLabel twice to Idea", %{idea_label: idea_label, idea: idea} do
       # Calling this method twice does not fail and does not create duplicates
       {:ok, idea_idea_label_after_method_call_1} =
-        IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+        IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
 
       {:ok, idea_idea_label_after_method_call_2} =
-        IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+        IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
 
       # There should still be only one IdeaIdeaLabel
       assert Repo.count(IdeaIdeaLabel) == 1
@@ -71,7 +71,7 @@ defmodule Mindwendel.IdeaLabelsTest do
         })
 
       {:error, _changeset} =
-        IdeaLabels.add_idea_label_to_idea(idea, idea_label_from_another_brainstorming)
+        IdeaLabels.add_idea_label_to_idea(idea, idea_label_from_another_brainstorming.id)
     end
 
     @tag :skip
@@ -95,7 +95,7 @@ defmodule Mindwendel.IdeaLabelsTest do
       idea = Repo.preload(idea, [:idea_labels, :idea_idea_labels])
       idea_label = idea.brainstorming.labels |> Enum.at(0)
 
-      IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
 
       assert Repo.count(IdeaIdeaLabel) == 1
       assert Repo.one(IdeaIdeaLabel).idea_id == idea.id
@@ -113,14 +113,14 @@ defmodule Mindwendel.IdeaLabelsTest do
 
   describe "#delete_idea_label_from_idea" do
     setup %{idea_label: idea_label, idea: idea} do
-      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label.id)
       idea = idea |> Repo.reload!() |> Repo.preload(:idea_labels)
       assert Repo.count(IdeaIdeaLabel) == 1
       %{idea: idea}
     end
 
     test "removes successfully IdeaLabel from Idea", %{idea_label: idea_label, idea: idea} do
-      IdeaLabels.remove_idea_label_from_idea(idea, idea_label)
+      IdeaLabels.remove_idea_label_from_idea(idea, idea_label.id)
       assert Enum.empty?(Repo.all(IdeaIdeaLabel))
     end
 
@@ -129,8 +129,8 @@ defmodule Mindwendel.IdeaLabelsTest do
       idea: idea
     } do
       # Calling this method twice does not fail
-      IdeaLabels.remove_idea_label_from_idea(idea, idea_label)
-      IdeaLabels.remove_idea_label_from_idea(idea, idea_label)
+      IdeaLabels.remove_idea_label_from_idea(idea, idea_label.id)
+      IdeaLabels.remove_idea_label_from_idea(idea, idea_label.id)
 
       assert Enum.empty?(Repo.all(IdeaIdeaLabel))
     end

--- a/test/mindwendel/idea_labels_test.exs
+++ b/test/mindwendel/idea_labels_test.exs
@@ -9,7 +9,7 @@ defmodule Mindwendel.IdeaLabelsTest do
 
   setup do
     brainstorming = Factory.insert!(:brainstorming, %{labels: [Factory.build(:idea_label)]})
-    idea_label = brainstorming.labels |> Enum.at(0)
+    [idea_label] = brainstorming.labels
     lane = Enum.at(brainstorming.lanes, 0)
     idea = Factory.insert!(:idea, %{brainstorming: brainstorming, lane: lane})
 
@@ -18,16 +18,16 @@ defmodule Mindwendel.IdeaLabelsTest do
 
   describe "#add_idea_label_to_idea" do
     test "adds IdeaLabel to Idea", %{idea_label: idea_label, idea: idea} do
-      {:ok, idea_changed} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
 
-      assert idea_changed.idea_labels |> Enum.count() == 1
-      assert Repo.all(IdeaIdeaLabel) |> Enum.count() == 1
+      assert [idea_label] == labels_of(idea)
+      assert Repo.count(IdeaIdeaLabel) == 1
     end
 
     test "creates one IdeaIdeaLabel", %{idea_label: idea_label, idea: idea} do
-      {:ok, _idea_changed} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
 
-      assert Repo.all(IdeaIdeaLabel) |> Enum.count() == 1
+      assert Repo.count(IdeaIdeaLabel) == 1
 
       idea_idea_label = Repo.one(IdeaIdeaLabel)
       assert idea_idea_label.idea_label_id == idea_label.id
@@ -35,26 +35,29 @@ defmodule Mindwendel.IdeaLabelsTest do
     end
 
     test "does not create additional IdeaLabel", %{idea_label: idea_label, idea: idea} do
-      assert Repo.all(IdeaLabel) |> Enum.count() == 1
+      assert Repo.count(IdeaLabel) == 1
 
-      {:ok, _idea_changed} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
 
-      assert Repo.all(IdeaLabel) |> Enum.count() == 1
+      assert Repo.count(IdeaLabel) == 1
       assert Repo.one(IdeaLabel) == idea_label
     end
 
     @tag :skip
     test "does not add the same IdeaLabel twice to Idea", %{idea_label: idea_label, idea: idea} do
       # Calling this method twice does not fail and does not create duplicates
-      {:ok, idea_after_method_call_1} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
-      {:ok, idea_after_method_call_2} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      {:ok, idea_idea_label_after_method_call_1} =
+        IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+
+      {:ok, idea_idea_label_after_method_call_2} =
+        IdeaLabels.add_idea_label_to_idea(idea, idea_label)
 
       # There should still be only one IdeaIdeaLabel
-      assert Repo.all(IdeaIdeaLabel) |> Enum.count() == 1
+      assert Repo.count(IdeaIdeaLabel) == 1
 
-      assert Repo.all(IdeaLabel) |> Enum.count() == 1
+      assert Repo.count(IdeaLabel) == 1
 
-      assert idea_after_method_call_1 == idea_after_method_call_2
+      assert idea_idea_label_after_method_call_1 == idea_idea_label_after_method_call_2
     end
 
     @tag :skip
@@ -88,16 +91,16 @@ defmodule Mindwendel.IdeaLabelsTest do
 
     @tag :skip
     test "does not create idea_labels without brainstorming", %{idea: idea} do
-      assert Repo.all(IdeaIdeaLabel) |> Enum.count() == 0
+      assert Repo.count(IdeaIdeaLabel) == 0
       idea = Repo.preload(idea, [:idea_labels, :idea_idea_labels])
       idea_label = idea.brainstorming.labels |> Enum.at(0)
 
       IdeaLabels.add_idea_label_to_idea(idea, idea_label)
 
-      assert Repo.all(IdeaIdeaLabel) |> Enum.count() == 1
+      assert Repo.count(IdeaIdeaLabel) == 1
       assert Repo.one(IdeaIdeaLabel).idea_id == idea.id
       assert Repo.one(IdeaIdeaLabel).idea_label_id == idea_label.id
-      assert Repo.all(IdeaLabel) |> Enum.count() == 5
+      assert Repo.count(IdeaLabel) == 5
 
       assert Enum.empty?(
                Repo.all(
@@ -110,8 +113,9 @@ defmodule Mindwendel.IdeaLabelsTest do
 
   describe "#delete_idea_label_from_idea" do
     setup %{idea_label: idea_label, idea: idea} do
-      {:ok, idea} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
-      assert Repo.all(IdeaIdeaLabel) |> Enum.count() == 1
+      {:ok, _idea_idea_label} = IdeaLabels.add_idea_label_to_idea(idea, idea_label)
+      idea = idea |> Repo.reload!() |> Repo.preload(:idea_labels)
+      assert Repo.count(IdeaIdeaLabel) == 1
       %{idea: idea}
     end
 
@@ -130,5 +134,13 @@ defmodule Mindwendel.IdeaLabelsTest do
 
       assert Enum.empty?(Repo.all(IdeaIdeaLabel))
     end
+  end
+
+  defp labels_of(idea_record) do
+    Repo.all(
+      from idea_label in IdeaLabel,
+        join: idea in assoc(idea_label, :ideas),
+        where: idea.id == ^idea_record.id
+    )
   end
 end


### PR DESCRIPTION
This was mostly me looking at SQL emitted when adding a new label.

This PR reduces the total amount of SQL queries issued for adding a label **from 20 to 14**
<details>
<summary>Log for add label before optimization</summary>

```
[debug] HANDLE EVENT "add_idea_label_to_idea" in MindwendelWeb.BrainstormingLive.Show
  Component: MindwendelWeb.IdeaLive.CardComponent
  Parameters: %{"idea-id" => "7c9dca19-94df-4653-b2db-1c2cc49edacc", "idea-label-id" => "84aedeef-eb27-4cb4-8804-05eca963b6e0"}
[debug] QUERY OK source="ideas" db=0.3ms idle=484.8ms
SELECT i0."id", i0."body", i0."position_order", i0."username", i0."comments_count", i0."user_id", i0."brainstorming_id", i0."lane_id", i0."inserted_at", i0."updated_at" FROM "ideas" AS i0 WHERE (i0."id" = $1) ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="idea_files" db=0.2ms idle=485.4ms
SELECT i0."id", i0."name", i0."path", i0."file_type", i0."idea_id", i0."inserted_at", i0."updated_at", i0."idea_id" FROM "idea_files" AS i0 WHERE (i0."idea_id" = $1) ORDER BY i0."idea_id" ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="idea_comments" db=0.2ms idle=485.5ms
SELECT i0."id", i0."idea_id", i0."user_id", i0."body", i0."username", i0."inserted_at", i0."updated_at", i0."idea_id" FROM "idea_comments" AS i0 WHERE (i0."idea_id" = $1) ORDER BY i0."idea_id", i0."inserted_at" DESC ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="links" db=0.3ms idle=485.6ms
SELECT l0."id", l0."url", l0."title", l0."description", l0."img_preview_url", l0."idea_id", l0."inserted_at", l0."updated_at", l0."idea_id" FROM "links" AS l0 WHERE (l0."idea_id" = $1) ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="idea_labels" db=1.1ms idle=485.4ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at", i1."idea_id"::uuid FROM "idea_labels" AS i0 INNER JOIN "idea_idea_labels" AS i1 ON i0."id" = i1."idea_label_id" WHERE (i1."idea_id" = ANY($1)) ORDER BY i1."idea_id"::uuid [["7c9dca19-94df-4653-b2db-1c2cc49edacc"]]
[debug] QUERY OK source="idea_labels" db=0.4ms idle=486.7ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at" FROM "idea_labels" AS i0 WHERE (i0."id" = $1) ["84aedeef-eb27-4cb4-8804-05eca963b6e0"]
[debug] QUERY OK db=0.1ms idle=487.3ms
begin []
[debug] QUERY OK source="idea_idea_labels" db=0.4ms
INSERT INTO "idea_idea_labels" ("idea_label_id","idea_id","inserted_at","updated_at") VALUES ($1,$2,$3,$4) ["84aedeef-eb27-4cb4-8804-05eca963b6e0", "7c9dca19-94df-4653-b2db-1c2cc49edacc", ~N[2024-11-30 18:37:32], ~N[2024-11-30 18:37:32]]
[debug] QUERY OK db=7.6ms
commit []
[debug] QUERY OK source="brainstormings" db=0.1ms idle=495.8ms
SELECT b0."id", b0."name", b0."option_allow_manual_ordering", b0."admin_url_id", b0."last_accessed_at", b0."filter_labels_ids", b0."creating_user_id", b0."inserted_at", b0."updated_at" FROM "brainstormings" AS b0 WHERE (b0."id" = $1) ["25a35202-c68d-4278-af69-382849134847"]
[debug] QUERY OK source="idea_labels" db=0.2ms idle=11.1ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at", i0."brainstorming_id" FROM "idea_labels" AS i0 WHERE (i0."brainstorming_id" = $1) ORDER BY i0."brainstorming_id", i0."position_order" ["25a35202-c68d-4278-af69-382849134847"]
[debug] QUERY OK source="users" db=0.4ms idle=496.1ms
SELECT u0."id", u0."username", u0."inserted_at", u0."updated_at", b1."brainstorming_id"::uuid FROM "users" AS u0 INNER JOIN "brainstorming_moderating_users" AS b1 ON u0."id" = b1."user_id" WHERE (b1."brainstorming_id" = ANY($1)) ORDER BY b1."brainstorming_id"::uuid [["25a35202-c68d-4278-af69-382849134847"]]
[debug] QUERY OK source="users" db=0.4ms idle=373.5ms
SELECT u0."id", u0."username", u0."inserted_at", u0."updated_at", b1."brainstorming_id"::uuid FROM "users" AS u0 INNER JOIN "brainstorming_users" AS b1 ON u0."id" = b1."user_id" WHERE (b1."brainstorming_id" = ANY($1)) ORDER BY b1."brainstorming_id"::uuid [["25a35202-c68d-4278-af69-382849134847"]]
[debug] QUERY OK source="brainstormings" db=1.0ms idle=11.1ms
UPDATE "brainstormings" SET "last_accessed_at" = $1, "updated_at" = $2 WHERE "id" = $3 [~U[2024-11-30 18:37:32Z], ~N[2024-11-30 18:37:32], "25a35202-c68d-4278-af69-382849134847"]
[debug] QUERY OK source="lanes" db=0.2ms idle=12.3ms
SELECT l0."id", l0."name", l0."position_order", l0."brainstorming_id", l0."inserted_at", l0."updated_at" FROM "lanes" AS l0 WHERE (l0."brainstorming_id" = $1) ORDER BY l0."position_order", l0."inserted_at" ["25a35202-c68d-4278-af69-382849134847"]
[debug] QUERY OK source="ideas" db=0.2ms idle=12.6ms
SELECT i0."id", i0."body", i0."position_order", i0."username", i0."comments_count", i0."user_id", i0."brainstorming_id", i0."lane_id", i0."inserted_at", i0."updated_at", i0."lane_id" FROM "ideas" AS i0 WHERE (i0."lane_id" = ANY($1)) ORDER BY i0."lane_id", i0."position_order", i0."inserted_at" [["ef8dbd09-f1be-410b-8e35-298ffaaf1a09", "69f02828-b1f7-4b73-a8a7-6177090fda22"]]
[debug] QUERY OK source="idea_files" db=0.1ms idle=3.3ms
SELECT i0."id", i0."name", i0."path", i0."file_type", i0."idea_id", i0."inserted_at", i0."updated_at", i0."idea_id" FROM "idea_files" AS i0 WHERE (i0."idea_id" = ANY($1)) ORDER BY i0."idea_id" [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] QUERY OK source="links" db=0.1ms idle=3.1ms
SELECT l0."id", l0."url", l0."title", l0."description", l0."img_preview_url", l0."idea_id", l0."inserted_at", l0."updated_at", l0."idea_id" FROM "links" AS l0 WHERE (l0."idea_id" = ANY($1)) [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] QUERY OK source="idea_labels" db=0.4ms idle=12.4ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at", i1."idea_id"::uuid FROM "idea_labels" AS i0 INNER JOIN "idea_idea_labels" AS i1 ON i0."id" = i1."idea_label_id" WHERE (i1."idea_id" = ANY($1)) ORDER BY i1."idea_id"::uuid [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] QUERY OK source="likes" db=0.4ms idle=11.9ms
SELECT l0."id", l0."idea_id", l0."user_id", l0."inserted_at", l0."updated_at", l0."idea_id" FROM "likes" AS l0 WHERE (l0."idea_id" = ANY($1)) ORDER BY l0."idea_id" [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] Replied in 15ms
```

</details>
<details>
<summary>Log for add label after optimization</summary>

```
[debug] HANDLE EVENT "add_idea_label_to_idea" in MindwendelWeb.BrainstormingLive.Show
  Component: MindwendelWeb.IdeaLive.CardComponent
  Parameters: %{"idea-id" => "7c9dca19-94df-4653-b2db-1c2cc49edacc", "idea-label-id" => "84aedeef-eb27-4cb4-8804-05eca963b6e0"}
[debug] QUERY OK source="ideas" db=0.5ms idle=1617.1ms
SELECT i0."id", i0."body", i0."position_order", i0."username", i0."comments_count", i0."user_id", i0."brainstorming_id", i0."lane_id", i0."inserted_at", i0."updated_at" FROM "ideas" AS i0 WHERE (i0."id" = $1) ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="idea_labels" db=0.3ms idle=624.0ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at", i1."idea_id"::uuid FROM "idea_labels" AS i0 INNER JOIN "idea_idea_labels" AS i1 ON i0."id" = i1."idea_label_id" WHERE (i1."idea_id" = ANY($1)) ORDER BY i1."idea_id"::uuid [["7c9dca19-94df-4653-b2db-1c2cc49edacc"]]
[debug] QUERY OK source="idea_files" db=0.2ms idle=617.9ms
SELECT i0."id", i0."name", i0."path", i0."file_type", i0."idea_id", i0."inserted_at", i0."updated_at", i0."idea_id" FROM "idea_files" AS i0 WHERE (i0."idea_id" = $1) ORDER BY i0."idea_id" ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="idea_comments" db=0.3ms idle=618.0ms
SELECT i0."id", i0."idea_id", i0."user_id", i0."body", i0."username", i0."inserted_at", i0."updated_at", i0."idea_id" FROM "idea_comments" AS i0 WHERE (i0."idea_id" = $1) ORDER BY i0."idea_id", i0."inserted_at" DESC ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="links" db=0.2ms idle=618.1ms
SELECT l0."id", l0."url", l0."title", l0."description", l0."img_preview_url", l0."idea_id", l0."inserted_at", l0."updated_at", l0."idea_id" FROM "links" AS l0 WHERE (l0."idea_id" = $1) ["7c9dca19-94df-4653-b2db-1c2cc49edacc"]
[debug] QUERY OK source="idea_labels" db=0.2ms idle=618.7ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at" FROM "idea_labels" AS i0 WHERE (i0."id" = $1) ["84aedeef-eb27-4cb4-8804-05eca963b6e0"]
[debug] QUERY OK source="idea_idea_labels" db=7.9ms queue=0.1ms idle=619.1ms
INSERT INTO "idea_idea_labels" ("idea_label_id","idea_id","inserted_at","updated_at") VALUES ($1,$2,$3,$4) ["84aedeef-eb27-4cb4-8804-05eca963b6e0", "7c9dca19-94df-4653-b2db-1c2cc49edacc", ~N[2024-11-30 19:37:49], ~N[2024-11-30 19:37:49]]
[debug] QUERY OK source="brainstormings" db=0.1ms idle=627.4ms
SELECT b0."id", b0."name", b0."option_allow_manual_ordering", b0."admin_url_id", b0."last_accessed_at", b0."filter_labels_ids", b0."creating_user_id", b0."inserted_at", b0."updated_at" FROM "brainstormings" AS b0 WHERE (b0."id" = $1) ["25a35202-c68d-4278-af69-382849134847"]
[debug] QUERY OK source="lanes" db=0.1ms idle=627.7ms
SELECT l0."id", l0."name", l0."position_order", l0."brainstorming_id", l0."inserted_at", l0."updated_at" FROM "lanes" AS l0 WHERE (l0."brainstorming_id" = $1) ORDER BY l0."position_order", l0."inserted_at" ["25a35202-c68d-4278-af69-382849134847"]
[debug] QUERY OK source="ideas" db=0.2ms idle=628.0ms
SELECT i0."id", i0."body", i0."position_order", i0."username", i0."comments_count", i0."user_id", i0."brainstorming_id", i0."lane_id", i0."inserted_at", i0."updated_at", i0."lane_id" FROM "ideas" AS i0 WHERE (i0."lane_id" = ANY($1)) ORDER BY i0."lane_id", i0."position_order", i0."inserted_at" [["ef8dbd09-f1be-410b-8e35-298ffaaf1a09", "69f02828-b1f7-4b73-a8a7-6177090fda22"]]
[debug] QUERY OK source="idea_labels" db=0.3ms idle=11.1ms
SELECT i0."id", i0."name", i0."color", i0."position_order", i0."brainstorming_id", i0."inserted_at", i0."updated_at", i1."idea_id"::uuid FROM "idea_labels" AS i0 INNER JOIN "idea_idea_labels" AS i1 ON i0."id" = i1."idea_label_id" WHERE (i1."idea_id" = ANY($1)) ORDER BY i1."idea_id"::uuid [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] QUERY OK source="likes" db=0.3ms idle=10.5ms
SELECT l0."id", l0."idea_id", l0."user_id", l0."inserted_at", l0."updated_at", l0."idea_id" FROM "likes" AS l0 WHERE (l0."idea_id" = ANY($1)) ORDER BY l0."idea_id" [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] QUERY OK source="idea_files" db=0.2ms idle=10.7ms
SELECT i0."id", i0."name", i0."path", i0."file_type", i0."idea_id", i0."inserted_at", i0."updated_at", i0."idea_id" FROM "idea_files" AS i0 WHERE (i0."idea_id" = ANY($1)) ORDER BY i0."idea_id" [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] QUERY OK source="links" db=0.2ms idle=10.8ms
SELECT l0."id", l0."url", l0."title", l0."description", l0."img_preview_url", l0."idea_id", l0."inserted_at", l0."updated_at", l0."idea_id" FROM "links" AS l0 WHERE (l0."idea_id" = ANY($1)) [["2dfd9635-f0e0-44e3-8acf-f080c681b07f", "f8b75443-8214-465a-af87-f0f87f1d3512", "30ca05a6-71e0-4fe1-9acf-9a99beaf50f8", "7c9dca19-94df-4653-b2db-1c2cc49edacc", "7bff94f2-e3e3-440d-8346-4c68a2ea00ab"]]
[debug] Replied in 12ms
```

</details>
That number is still relatively high (imo) but this is due to the decision of broadcasting a full "Lane change" instead of the incremental equivalent update (which I didn't wanna touch here/change without discussion).

The PR mainly does 2 things:
* limit what we do to add the label, as we discard the `idea` struct afterwards anyhow
* on the broadcast event, limit what brainstorming loads as all its preloads don't matter

There is some further potential here, I'll highlight some and will check out some more one of these days for similar patterns.