### PR TITLE
Catch wrong UUID and missing brainstorming

### DIFF
--- a/lib/mindwendel/brainstormings.ex
+++ b/lib/mindwendel/brainstormings.ex
@@ -59,10 +59,10 @@ defmodule Mindwendel.Brainstormings do
       %Brainstorming{ ... }
 
       iex> get_brainstorming("0323906b-b496-4778-ae67-1dd779d3de3c")
-      ** (Ecto.NoResultsError)
+      {:error, :not_found}
 
       iex> get_brainstorming("not_a_valid_uuid_string")
-      ** (Ecto.Query.CastError)
+      {:error, :invalid_uuid}
 
   """
   def get_brainstorming(id) do

--- a/lib/mindwendel/lanes.ex
+++ b/lib/mindwendel/lanes.ex
@@ -70,7 +70,7 @@ defmodule Mindwendel.Lanes do
 
   """
   def get_lanes_for_brainstorming_with_labels_filtered(id) do
-    brainstorming = Brainstormings.get_brainstorming(id)
+    {:ok, brainstorming} = Brainstormings.get_brainstorming(id)
 
     filter_label =
       if length(brainstorming.filter_labels_ids) > 0,

--- a/lib/mindwendel/lanes.ex
+++ b/lib/mindwendel/lanes.ex
@@ -70,7 +70,7 @@ defmodule Mindwendel.Lanes do
 
   """
   def get_lanes_for_brainstorming_with_labels_filtered(id) do
-    brainstorming = Brainstormings.get_brainstorming!(id)
+    brainstorming = Brainstormings.get_brainstorming(id)
 
     filter_label =
       if length(brainstorming.filter_labels_ids) > 0,

--- a/lib/mindwendel_web/live/brainstorming_live/show.ex
+++ b/lib/mindwendel_web/live/brainstorming_live/show.ex
@@ -16,7 +16,7 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
     # If the admin secret in the URL after the hash (only available inside the client session) is given, add the user as moderating user to the brainstorming.
     # If not, add the user as normal user.
     current_user_id = Mindwendel.Services.SessionService.get_current_user_id(session)
-    brainstorming = Brainstormings.get_brainstorming!(id)
+    brainstorming = Brainstormings.get_brainstorming(id)
     admin_secret = get_connect_params(socket)["adminSecret"]
 
     if Brainstormings.validate_admin_secret(brainstorming, admin_secret) do

--- a/lib/mindwendel_web/live/brainstorming_live/show.ex
+++ b/lib/mindwendel_web/live/brainstorming_live/show.ex
@@ -17,13 +17,7 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
     current_user_id = Mindwendel.Services.SessionService.get_current_user_id(session)
 
     case Brainstormings.get_brainstorming(id) do
-      {:error, _} ->
-        {:ok,
-         socket
-         |> put_flash(:error, gettext("Brainstorming not found"))
-         |> push_navigate(to: "/")}
-
-      brainstorming ->
+      {:ok, brainstorming} ->
         admin_secret = get_connect_params(socket)["adminSecret"]
 
         if Brainstormings.validate_admin_secret(brainstorming, admin_secret) do
@@ -44,6 +38,12 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
           |> assign(:current_user, current_user)
           |> assign(:inspiration, Mindwendel.Help.random_inspiration())
         }
+
+      {:error, _} ->
+        {:ok,
+         socket
+         |> put_flash(:error, gettext("Brainstorming not found"))
+         |> push_navigate(to: "/")}
     end
   end
 

--- a/lib/mindwendel_web/live/lane_live/index_component.ex
+++ b/lib/mindwendel_web/live/lane_live/index_component.ex
@@ -31,7 +31,7 @@ defmodule MindwendelWeb.LaneLive.IndexComponent do
         },
         socket
       ) do
-    brainstorming = Brainstormings.get_brainstorming!(brainstorming_id)
+    brainstorming = Brainstormings.get_brainstorming(brainstorming_id)
 
     if has_move_permission(brainstorming, socket.assigns.current_user) do
       Ideas.update_ideas_for_brainstorming_by_user_move(
@@ -62,7 +62,7 @@ defmodule MindwendelWeb.LaneLive.IndexComponent do
   end
 
   def handle_event("sort_by_likes", %{"id" => id, "lane-id" => lane_id}, socket) do
-    brainstorming = Brainstormings.get_brainstorming!(id)
+    brainstorming = Brainstormings.get_brainstorming(id)
 
     if has_move_permission(brainstorming, socket.assigns.current_user) do
       Ideas.update_ideas_for_brainstorming_by_likes(id, lane_id)
@@ -72,7 +72,7 @@ defmodule MindwendelWeb.LaneLive.IndexComponent do
   end
 
   def handle_event("sort_by_label", %{"id" => id, "lane-id" => lane_id}, socket) do
-    brainstorming = Brainstormings.get_brainstorming!(id)
+    brainstorming = Brainstormings.get_brainstorming(id)
 
     if has_move_permission(brainstorming, socket.assigns.current_user) do
       Ideas.update_ideas_for_brainstorming_by_labels(id, lane_id)

--- a/lib/mindwendel_web/live/lane_live/index_component.ex
+++ b/lib/mindwendel_web/live/lane_live/index_component.ex
@@ -31,7 +31,7 @@ defmodule MindwendelWeb.LaneLive.IndexComponent do
         },
         socket
       ) do
-    brainstorming = Brainstormings.get_brainstorming(brainstorming_id)
+    {:ok, brainstorming} = Brainstormings.get_brainstorming(brainstorming_id)
 
     if has_move_permission(brainstorming, socket.assigns.current_user) do
       Ideas.update_ideas_for_brainstorming_by_user_move(
@@ -62,7 +62,7 @@ defmodule MindwendelWeb.LaneLive.IndexComponent do
   end
 
   def handle_event("sort_by_likes", %{"id" => id, "lane-id" => lane_id}, socket) do
-    brainstorming = Brainstormings.get_brainstorming(id)
+    {:ok, brainstorming} = Brainstormings.get_brainstorming(id)
 
     if has_move_permission(brainstorming, socket.assigns.current_user) do
       Ideas.update_ideas_for_brainstorming_by_likes(id, lane_id)
@@ -72,7 +72,7 @@ defmodule MindwendelWeb.LaneLive.IndexComponent do
   end
 
   def handle_event("sort_by_label", %{"id" => id, "lane-id" => lane_id}, socket) do
-    brainstorming = Brainstormings.get_brainstorming(id)
+    {:ok, brainstorming} = Brainstormings.get_brainstorming(id)
 
     if has_move_permission(brainstorming, socket.assigns.current_user) do
       Ideas.update_ideas_for_brainstorming_by_labels(id, lane_id)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -563,7 +563,7 @@ msgstr "Detailansicht"
 msgid "Give moderating permissions"
 msgstr "Änderungen erlauben"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:23
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming not found"
 msgstr "Brainstorming konnte nicht gefunden werden"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -26,12 +26,12 @@ msgstr "Wie können wir ..."
 msgid "Ready?"
 msgstr "Fertig?"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:175
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:184
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr "%{name} - Editieren"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:152
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:161
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr "%{name} - Neue Idee"
@@ -299,7 +299,7 @@ msgstr "Bist du sicher, dass das Brainstorming geleert werden soll?"
 msgid "Empty brainstorming"
 msgstr "Leere das Brainstorming"
 
-#: lib/mindwendel_web/live/live_helpers.ex:29
+#: lib/mindwendel_web/live/live_helpers.ex:30
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming will be deleted %{days}"
 msgstr "Brainstorming wird gelöscht %{days}"
@@ -385,7 +385,7 @@ msgstr "Löschen"
 msgid "Type the label name"
 msgstr "Gebe dem Label einen Namen"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:162
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} - New Lane"
 msgstr "%{name} - Neue Idee"
@@ -562,3 +562,8 @@ msgstr "Detailansicht"
 #, elixir-autogen, elixir-format
 msgid "Give moderating permissions"
 msgstr "Änderungen erlauben"
+
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:23
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Brainstorming not found"
+msgstr "Brainstorming konnte nicht gefunden werden"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -562,7 +562,7 @@ msgstr ""
 msgid "Give moderating permissions"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:23
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:45
 #, elixir-autogen, elixir-format
 msgid "Brainstorming not found"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -25,12 +25,12 @@ msgstr ""
 msgid "Ready?"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:176
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:184
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:153
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:161
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:163
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:171
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Lane"
 msgstr ""
@@ -560,4 +560,9 @@ msgstr ""
 #: lib/mindwendel_web/live/brainstorming_live/share_component.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Give moderating permissions"
+msgstr ""
+
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:23
+#, elixir-autogen, elixir-format
+msgid "Brainstorming not found"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Give moderating permissions"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:23
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming not found"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -26,12 +26,12 @@ msgstr ""
 msgid "Ready?"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:175
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:184
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:152
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:161
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr ""
@@ -299,7 +299,7 @@ msgstr "Are you sure that you want to delete this brainstorming?"
 msgid "Empty brainstorming"
 msgstr ""
 
-#: lib/mindwendel_web/live/live_helpers.ex:29
+#: lib/mindwendel_web/live/live_helpers.ex:30
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming will be deleted %{days}"
 msgstr ""
@@ -385,7 +385,7 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:162
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} - New Lane"
 msgstr ""
@@ -561,4 +561,9 @@ msgstr ""
 #: lib/mindwendel_web/live/brainstorming_live/share_component.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Give moderating permissions"
+msgstr ""
+
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:23
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Brainstorming not found"
 msgstr ""

--- a/test/mindwendel/accounts_test.exs
+++ b/test/mindwendel/accounts_test.exs
@@ -33,7 +33,7 @@ defmodule Mindwendel.AccountsTest do
       assert brainstorming_moderatoring_user.brainstorming_id == brainstorming.id
 
       assert [%User{id: ^user_id}] =
-               Brainstormings.get_brainstorming!(brainstorming.id).moderating_users
+               Brainstormings.get_brainstorming(brainstorming.id).moderating_users
     end
 
     test "responds with an error when brainstorming already contains the moderating user", %{

--- a/test/mindwendel/accounts_test.exs
+++ b/test/mindwendel/accounts_test.exs
@@ -32,8 +32,8 @@ defmodule Mindwendel.AccountsTest do
       assert brainstorming_moderatoring_user.user_id == user.id
       assert brainstorming_moderatoring_user.brainstorming_id == brainstorming.id
 
-      assert [%User{id: ^user_id}] =
-               Brainstormings.get_brainstorming(brainstorming.id).moderating_users
+      {:ok, brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
+      assert [%User{id: ^user_id}] = brainstorming.moderating_users
     end
 
     test "responds with an error when brainstorming already contains the moderating user", %{

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -27,6 +27,27 @@ defmodule Mindwendel.BrainstormingsTest do
     }
   end
 
+  describe "get_brainstorming" do
+    test "returns the brainstorming", %{brainstorming: brainstorming} do
+      {:ok, loaded_brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
+      assert loaded_brainstorming.id == brainstorming.id
+    end
+
+    test "returns an error for the wrong uuid" do
+      assert {:error, :invalid_uuid} == Brainstormings.get_brainstorming("invalid_uuid")
+    end
+
+    test "returns an error for a missing brainstorming" do
+      assert {:error, :not_found} ==
+               Brainstormings.get_brainstorming("8a4f5d37-28c4-424e-ac4a-5637a41486c4")
+    end
+
+    test "returns an error for a nil value" do
+      assert {:error, :invalid_uuid} ==
+               Brainstormings.get_brainstorming(nil)
+    end
+  end
+
   describe "validate_admin_secret" do
     test "returns false if secret is wrong", %{brainstorming: brainstorming} do
       refute Brainstormings.validate_admin_secret(brainstorming, "wrong")

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -253,7 +253,7 @@ defmodule Mindwendel.BrainstormingsTest do
       assert Enum.count(brainstorming.ideas) == 1
       Brainstormings.empty(brainstorming)
       # reload brainstorming:
-      brainstorming = Brainstormings.get_brainstorming!(brainstorming.id)
+      brainstorming = Brainstormings.get_brainstorming(brainstorming.id)
       brainstorming = brainstorming |> Repo.preload([:ideas, :lanes])
       assert Enum.empty?(brainstorming.lanes)
     end
@@ -302,7 +302,7 @@ defmodule Mindwendel.BrainstormingsTest do
       assert Enum.count(other_brainstorming.ideas) == 1
       Brainstormings.empty(brainstorming)
       # reload brainstorming:
-      brainstorming = Brainstormings.get_brainstorming!(brainstorming.id) |> Repo.preload(:lanes)
+      brainstorming = Brainstormings.get_brainstorming(brainstorming.id) |> Repo.preload(:lanes)
       brainstorming = brainstorming |> Repo.preload([:ideas])
       other_brainstorming = other_brainstorming |> Repo.preload([:ideas])
       assert Enum.empty?(brainstorming.lanes)

--- a/test/mindwendel/brainstormings_test.exs
+++ b/test/mindwendel/brainstormings_test.exs
@@ -32,6 +32,11 @@ defmodule Mindwendel.BrainstormingsTest do
       refute Brainstormings.validate_admin_secret(brainstorming, "wrong")
     end
 
+    test "returns false if secret is nil", %{brainstorming: brainstorming} do
+      brainstorming = %{brainstorming | admin_url_id: nil}
+      refute Brainstormings.validate_admin_secret(brainstorming, nil)
+    end
+
     test "returns true if secret is correct", %{brainstorming: brainstorming} do
       assert Brainstormings.validate_admin_secret(brainstorming, brainstorming.admin_url_id)
     end
@@ -253,7 +258,7 @@ defmodule Mindwendel.BrainstormingsTest do
       assert Enum.count(brainstorming.ideas) == 1
       Brainstormings.empty(brainstorming)
       # reload brainstorming:
-      brainstorming = Brainstormings.get_brainstorming(brainstorming.id)
+      {:ok, brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
       brainstorming = brainstorming |> Repo.preload([:ideas, :lanes])
       assert Enum.empty?(brainstorming.lanes)
     end
@@ -302,8 +307,8 @@ defmodule Mindwendel.BrainstormingsTest do
       assert Enum.count(other_brainstorming.ideas) == 1
       Brainstormings.empty(brainstorming)
       # reload brainstorming:
-      brainstorming = Brainstormings.get_brainstorming(brainstorming.id) |> Repo.preload(:lanes)
-      brainstorming = brainstorming |> Repo.preload([:ideas])
+      {:ok, brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
+      brainstorming = brainstorming |> Repo.preload([:ideas, :lanes])
       other_brainstorming = other_brainstorming |> Repo.preload([:ideas])
       assert Enum.empty?(brainstorming.lanes)
       assert Enum.count(other_brainstorming.lanes) == 1

--- a/test/mindwendel_web/live/admin/brainstorming_live/edit_test.exs
+++ b/test/mindwendel_web/live/admin/brainstorming_live/edit_test.exs
@@ -89,7 +89,9 @@ defmodule MindwendelWeb.Admin.BrainstormingLive.EditTest do
            |> form("#form-labels", %{brainstorming: %{labels: %{"0": %{name: "new label"}}}})
            |> render_change()
 
-    assert Brainstormings.get_brainstorming(brainstorming.id).labels
+    {:ok, brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
+
+    assert brainstorming.labels
            |> Enum.map(fn a -> a.name end)
            |> Enum.member?("new label")
   end

--- a/test/mindwendel_web/live/admin/brainstorming_live/edit_test.exs
+++ b/test/mindwendel_web/live/admin/brainstorming_live/edit_test.exs
@@ -89,7 +89,7 @@ defmodule MindwendelWeb.Admin.BrainstormingLive.EditTest do
            |> form("#form-labels", %{brainstorming: %{labels: %{"0": %{name: "new label"}}}})
            |> render_change()
 
-    assert Brainstormings.get_brainstorming!(brainstorming.id).labels
+    assert Brainstormings.get_brainstorming(brainstorming.id).labels
            |> Enum.map(fn a -> a.name end)
            |> Enum.member?("new label")
   end

--- a/test/mindwendel_web/live/brainstorming_live_test.exs
+++ b/test/mindwendel_web/live/brainstorming_live_test.exs
@@ -303,7 +303,7 @@ defmodule MindwendelWeb.BrainstormingLiveTest do
       |> render_click()
 
       assert(
-        Brainstormings.get_brainstorming!(brainstorming.id).filter_labels_ids == [
+        Brainstormings.get_brainstorming(brainstorming.id).filter_labels_ids == [
           selected_ideal_label.id
         ]
       )

--- a/test/mindwendel_web/live/brainstorming_live_test.exs
+++ b/test/mindwendel_web/live/brainstorming_live_test.exs
@@ -302,8 +302,10 @@ defmodule MindwendelWeb.BrainstormingLiveTest do
       |> element(".btn[data-testid=\"#{selected_ideal_label.id}\"]")
       |> render_click()
 
+      {:ok, brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
+
       assert(
-        Brainstormings.get_brainstorming(brainstorming.id).filter_labels_ids == [
+        brainstorming.filter_labels_ids == [
           selected_ideal_label.id
         ]
       )

--- a/test/mindwendel_web/live/label_live/captions_test.exs
+++ b/test/mindwendel_web/live/label_live/captions_test.exs
@@ -17,7 +17,7 @@ defmodule MindwendelWeb.LabelLive.CaptionsTest do
     brainstorming: brainstorming,
     user: user
   } do
-    preloaded_brainstorming = Brainstormings.get_brainstorming(brainstorming.id)
+    {:ok, preloaded_brainstorming} = Brainstormings.get_brainstorming(brainstorming.id)
     preloaded_user = Accounts.get_user(user.id)
 
     captions_component =

--- a/test/mindwendel_web/live/label_live/captions_test.exs
+++ b/test/mindwendel_web/live/label_live/captions_test.exs
@@ -17,7 +17,7 @@ defmodule MindwendelWeb.LabelLive.CaptionsTest do
     brainstorming: brainstorming,
     user: user
   } do
-    preloaded_brainstorming = Brainstormings.get_brainstorming!(brainstorming.id)
+    preloaded_brainstorming = Brainstormings.get_brainstorming(brainstorming.id)
     preloaded_user = Accounts.get_user(user.id)
 
     captions_component =


### PR DESCRIPTION
## Further Notes

Improves the initial brainstorming fetch and tries to avoid throwing an exception when the uuid is in the wrong format or the brainstorming couldn't be found. Exceptions should not be expected.

Redirects to landing page and shows an alert in these cases.