### PR TITLE
fix teaser feature flag in brainstorming show

### DIFF
--- a/lib/mindwendel_web/live/brainstorming_live/show.ex
+++ b/lib/mindwendel_web/live/brainstorming_live/show.ex
@@ -7,6 +7,7 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
   alias Mindwendel.Ideas
   alias Mindwendel.Brainstormings.Idea
   alias Mindwendel.Brainstormings.Lane
+  alias Mindwendel.FeatureFlag
   alias Mindwendel.LocalStorage
 
   @impl true
@@ -41,7 +42,7 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
           |> assign(:lanes, lanes)
           |> assign(:filtered_labels, brainstorming.filter_labels_ids)
           |> assign(:current_user, current_user)
-          |> assign(:inspiration, Mindwendel.Help.random_inspiration())
+          |> assign(:inspiration, inspiration())
         }
 
       {:error, _} ->
@@ -200,5 +201,11 @@ defmodule MindwendelWeb.BrainstormingLive.Show do
   defp apply_action(socket, :share, _params) do
     socket
     |> assign(:page_title, socket.assigns.brainstorming.name)
+  end
+
+  defp inspiration do
+    if FeatureFlag.enabled?(:feature_brainstorming_teasers) do
+      Mindwendel.Help.random_inspiration()
+    end
   end
 end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -26,12 +26,12 @@ msgstr "Wie können wir ..."
 msgid "Ready?"
 msgstr "Fertig?"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:197
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:198
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr "%{name} - Editieren"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:174
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr "%{name} - Neue Idee"
@@ -385,7 +385,7 @@ msgstr "Löschen"
 msgid "Type the label name"
 msgstr "Gebe dem Label einen Namen"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:184
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:185
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} - New Lane"
 msgstr "%{name} - Neue Idee"
@@ -563,7 +563,7 @@ msgstr "Detailansicht"
 msgid "Give moderating permissions"
 msgstr "Änderungen erlauben"
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:51
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming not found"
 msgstr "Brainstorming konnte nicht gefunden werden"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -25,12 +25,12 @@ msgstr ""
 msgid "Ready?"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:197
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:198
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:174
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:184
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:185
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Lane"
 msgstr ""
@@ -562,7 +562,7 @@ msgstr ""
 msgid "Give moderating permissions"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:51
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:52
 #, elixir-autogen, elixir-format
 msgid "Brainstorming not found"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -26,12 +26,12 @@ msgstr ""
 msgid "Ready?"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:197
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:198
 #, elixir-autogen, elixir-format
 msgid "%{name} - Edit"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:174
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:175
 #, elixir-autogen, elixir-format
 msgid "%{name} - New Idea"
 msgstr ""
@@ -385,7 +385,7 @@ msgstr ""
 msgid "Type the label name"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:184
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:185
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} - New Lane"
 msgstr ""
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Give moderating permissions"
 msgstr ""
 
-#: lib/mindwendel_web/live/brainstorming_live/show.ex:51
+#: lib/mindwendel_web/live/brainstorming_live/show.ex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Brainstorming not found"
 msgstr ""


### PR DESCRIPTION
Apparently the feature flag check was accidentally removed inside the live view brainstormings/show.