### PR TITLE
Harden url preview

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -34,3 +34,6 @@ config :gettext, :default_locale, "en"
 config :timex, :default_locale, "en"
 
 config :mindwendel, Oban, repo: Mindwendel.Repo, testing: :inline
+
+# Allow private IPs for URL preview in tests
+config :mindwendel, :allow_private_ips, true

--- a/lib/mindwendel/application.ex
+++ b/lib/mindwendel/application.ex
@@ -34,6 +34,8 @@ defmodule Mindwendel.Application do
       # Start the Endpoint (http/https)
       MindwendelWeb.Endpoint,
       Mindwendel.Services.Vault,
+      # Start Task Supervisor for supervised async tasks
+      {Task.Supervisor, name: Mindwendel.TaskSupervisor},
       # Start a worker by calling: Mindwendel.Worker.start_link(arg)
       # {Mindwendel.Worker, arg}
       {Oban, oban_config()}

--- a/lib/mindwendel/url_preview.ex
+++ b/lib/mindwendel/url_preview.ex
@@ -14,8 +14,53 @@ defmodule Mindwendel.UrlPreview do
   end
 
   def fetch_url(url \\ "") do
-    HTTPoison.start()
-    url |> HTTPoison.get() |> handle_response |> handle_parsing
+    with {:ok, uri} <- URI.new(url),
+         true <- uri.scheme in ["http", "https"],
+         true <- valid_host?(uri.host) do
+      HTTPoison.start()
+
+      url
+      |> HTTPoison.get(
+        [],
+        timeout: 5_000,
+        recv_timeout: 5_000,
+        max_redirect: 3,
+        follow_redirect: true
+      )
+      |> handle_response()
+      |> handle_parsing()
+    else
+      _ -> {:error, title: "", description: "", img_preview_url: ""}
+    end
+  end
+
+  defp valid_host?(host) when is_nil(host), do: false
+
+  defp valid_host?(host) do
+    # Allow localhost in test environment only
+    if Mix.env() == :test do
+      true
+    else
+      # Block private IP ranges and localhost in production/dev
+      case :inet.getaddr(String.to_charlist(host), :inet) do
+        # localhost
+        {:ok, {127, _, _, _}} -> false
+        # private 10.x.x.x
+        {:ok, {10, _, _, _}} -> false
+        # private 172.16-31.x.x
+        {:ok, {172, second, _, _}} when second >= 16 and second <= 31 -> false
+        # private 192.168.x.x
+        {:ok, {192, 168, _, _}} -> false
+        # link-local / cloud metadata
+        {:ok, {169, 254, _, _}} -> false
+        # invalid
+        {:ok, {0, 0, 0, 0}} -> false
+        # public IP
+        {:ok, _} -> true
+        # DNS resolution failed
+        {:error, _} -> false
+      end
+    end
   end
 
   defp handle_parsing({:ok, parsed_document}) do

--- a/lib/mindwendel/url_preview.ex
+++ b/lib/mindwendel/url_preview.ex
@@ -38,48 +38,39 @@ defmodule Mindwendel.UrlPreview do
 
   defp valid_host?(host) do
     # Allow localhost in test environment only
-    if Mix.env() == :test do
+    if allow_private_ips?() do
       true
     else
-      # Block private IP ranges and localhost to prevent SSRF attacks.
-      # These ranges are defined by RFC 1918 (private networks) and RFC 3927 (link-local).
-      # The 169.254.x.x range is particularly dangerous as it includes cloud metadata endpoints
-      # (AWS, GCP, Azure) that expose credentials and sensitive configuration.
-      case :inet.getaddr(String.to_charlist(host), :inet) do
-        # localhost
-        {:ok, {127, _, _, _}} ->
-          false
-
-        # private 10.x.x.x (RFC 1918)
-        {:ok, {10, _, _, _}} ->
-          false
-
-        # private 172.16.0.0 - 172.31.255.255 (RFC 1918)
-        {:ok, {172, second, _, _}} when second >= 16 and second <= 31 ->
-          false
-
-        # private 192.168.x.x (RFC 1918)
-        {:ok, {192, 168, _, _}} ->
-          false
-
-        # link-local / cloud metadata 169.254.x.x (RFC 3927)
-        {:ok, {169, 254, _, _}} ->
-          false
-
-        # invalid
-        {:ok, {0, 0, 0, 0}} ->
-          false
-
-        # public IP
-        {:ok, _} ->
-          true
-
-        # DNS resolution failed
-        {:error, _} ->
-          false
-      end
+      check_public_ip(host)
     end
   end
+
+  defp allow_private_ips? do
+    Application.get_env(:mindwendel, :allow_private_ips, false)
+  end
+
+  defp check_public_ip(host) do
+    # Block private IP ranges and localhost to prevent SSRF attacks.
+    # These ranges are defined by RFC 1918 (private networks) and RFC 3927 (link-local).
+    # The 169.254.x.x range is particularly dangerous as it includes cloud metadata endpoints
+    # (AWS, GCP, Azure) that expose credentials and sensitive configuration.
+    case :inet.getaddr(String.to_charlist(host), :inet) do
+      {:ok, ip_tuple} -> public_ip?(ip_tuple)
+      {:error, _} -> false
+    end
+  end
+
+  defp public_ip?(ip_tuple) do
+    not private_ip?(ip_tuple)
+  end
+
+  defp private_ip?({127, _, _, _}), do: true
+  defp private_ip?({10, _, _, _}), do: true
+  defp private_ip?({172, second, _, _}) when second >= 16 and second <= 31, do: true
+  defp private_ip?({192, 168, _, _}), do: true
+  defp private_ip?({169, 254, _, _}), do: true
+  defp private_ip?({0, 0, 0, 0}), do: true
+  defp private_ip?(_), do: false
 
   defp handle_parsing({:ok, parsed_document}) do
     {

--- a/test/mindwendel/url_preview_test.exs
+++ b/test/mindwendel/url_preview_test.exs
@@ -29,6 +29,22 @@ defmodule MindwendelServices.UrlPreviewTest do
     test "extracts empty string if no url is given" do
       assert "" = UrlPreview.extract_url("No Url here")
     end
+
+    test "extracts empty string for empty string" do
+      assert "" = UrlPreview.extract_url("")
+    end
+
+    test "extracts https urls" do
+      assert "https://secure.example.com" =
+               UrlPreview.extract_url("Check out https://secure.example.com")
+    end
+
+    test "extracts urls with complex paths" do
+      assert "https://example.com/path/to/resource?foo=bar&baz=qux#anchor" =
+               UrlPreview.extract_url(
+                 "https://example.com/path/to/resource?foo=bar&baz=qux#anchor"
+               )
+    end
   end
 
   describe "fetch_url" do
@@ -60,6 +76,204 @@ defmodule MindwendelServices.UrlPreviewTest do
       end)
 
       assert {:error, _} = UrlPreview.fetch_url(endpoint_url(bypass.port) <> "/some_post")
+    end
+
+    test "truncates long titles to 300 characters", %{bypass: bypass} do
+      long_title = String.duplicate("A", 400)
+
+      Bypass.expect_once(bypass, "GET", "/long_title", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html><title>#{long_title}</title></html>")
+      end)
+
+      assert {:ok, title: title, description: "", img_preview_url: ""} =
+               UrlPreview.fetch_url(endpoint_url(bypass.port) <> "/long_title")
+
+      assert String.length(title) == 300
+    end
+
+    test "truncates long descriptions to 300 characters", %{bypass: bypass} do
+      long_desc = String.duplicate("B", 400)
+
+      Bypass.expect_once(bypass, "GET", "/long_desc", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><title>Title</title><meta name='description' content='#{long_desc}'></html>"
+        )
+      end)
+
+      assert {:ok, title: "Title", description: description, img_preview_url: ""} =
+               UrlPreview.fetch_url(endpoint_url(bypass.port) <> "/long_desc")
+
+      assert String.length(description) == 300
+    end
+
+    test "handles malformed HTML gracefully", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/malformed", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html><title>Unclosed title<body>Content</html>")
+      end)
+
+      assert {:ok, _} = UrlPreview.fetch_url(endpoint_url(bypass.port) <> "/malformed")
+    end
+
+    test "handles various HTTP error codes", %{bypass: bypass} do
+      for status_code <- [301, 302, 400, 401, 403, 500, 502, 503] do
+        Bypass.expect_once(bypass, "GET", "/status_#{status_code}", fn conn ->
+          Plug.Conn.resp(conn, status_code, "")
+        end)
+
+        assert {:error, _} =
+                 UrlPreview.fetch_url(endpoint_url(bypass.port) <> "/status_#{status_code}")
+      end
+    end
+
+    test "returns error for invalid URI" do
+      assert {:error, _} = UrlPreview.fetch_url("not a valid uri")
+    end
+
+    test "returns error for empty URL" do
+      assert {:error, _} = UrlPreview.fetch_url("")
+    end
+
+    test "returns error for non-HTTP schemes" do
+      assert {:error, _} = UrlPreview.fetch_url("ftp://example.com")
+      assert {:error, _} = UrlPreview.fetch_url("file:///etc/passwd")
+      assert {:error, _} = UrlPreview.fetch_url("javascript:alert(1)")
+    end
+
+    test "handles connection errors gracefully", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:error, _} = UrlPreview.fetch_url(endpoint_url(bypass.port) <> "/some_post")
+    end
+  end
+
+  describe "private IP validation (SSRF protection)" do
+    test "blocks localhost addresses when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        assert {:error, _} = UrlPreview.fetch_url("http://localhost/")
+        assert {:error, _} = UrlPreview.fetch_url("http://127.0.0.1/")
+        assert {:error, _} = UrlPreview.fetch_url("http://127.0.0.255/")
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
+    end
+
+    test "blocks private IP ranges when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        # 10.0.0.0/8 - RFC 1918 private network
+        assert {:error, _} = UrlPreview.fetch_url("http://10.0.0.1/")
+        assert {:error, _} = UrlPreview.fetch_url("http://10.255.255.255/")
+
+        # 172.16.0.0/12 - RFC 1918 private network
+        assert {:error, _} = UrlPreview.fetch_url("http://172.16.0.1/")
+        assert {:error, _} = UrlPreview.fetch_url("http://172.31.255.255/")
+
+        # 192.168.0.0/16 - RFC 1918 private network
+        assert {:error, _} = UrlPreview.fetch_url("http://192.168.1.1/")
+        assert {:error, _} = UrlPreview.fetch_url("http://192.168.255.255/")
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
+    end
+
+    test "blocks link-local addresses (cloud metadata endpoints) when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        # 169.254.0.0/16 - Link-local/APIPA (includes cloud metadata at 169.254.169.254)
+        assert {:error, _} = UrlPreview.fetch_url("http://169.254.169.254/")
+        assert {:error, _} = UrlPreview.fetch_url("http://169.254.0.1/")
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
+    end
+
+    test "blocks 0.0.0.0 when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        assert {:error, _} = UrlPreview.fetch_url("http://0.0.0.0/")
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
+    end
+
+    test "allows public IPs when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        # These will fail to connect, but should pass IP validation
+        # We're testing that they don't return error due to IP blocking
+        # Note: 8.8.8.8 is Google's public DNS
+        result = UrlPreview.fetch_url("http://8.8.8.8/")
+        # Should get connection error, not IP blocking error
+        # The error tuple format is the same, but we can verify it attempts the connection
+        assert {:error, _} = result
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
+    end
+
+    test "allows localhost when allow_private_ips is true", %{bypass: bypass} do
+      # This is the default test configuration
+      assert Application.get_env(:mindwendel, :allow_private_ips) == true
+
+      Bypass.expect_once(bypass, "GET", "/", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html><title>Allowed</title></html>")
+      end)
+
+      assert {:ok, title: "Allowed", description: "", img_preview_url: ""} =
+               UrlPreview.fetch_url(endpoint_url(bypass.port))
+    end
+
+    test "blocks edge case IP addresses in 172.x range when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        # Should block 172.16-31.x.x
+        assert {:error, _} = UrlPreview.fetch_url("http://172.20.0.1/")
+
+        # Should NOT block 172.15.x.x or 172.32.x.x (outside the range)
+        # These will fail with connection errors, not IP validation errors
+        # We can't easily test the difference in error types without mocking,
+        # but at minimum they should not hang or crash
+        result1 = UrlPreview.fetch_url("http://172.15.0.1/")
+        result2 = UrlPreview.fetch_url("http://172.32.0.1/")
+        assert {:error, _} = result1
+        assert {:error, _} = result2
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
+    end
+
+    test "blocks hostname that resolves to private IP when allow_private_ips is false" do
+      original_config = Application.get_env(:mindwendel, :allow_private_ips)
+
+      try do
+        Application.put_env(:mindwendel, :allow_private_ips, false)
+
+        # "localhost" should resolve to 127.0.0.1
+        assert {:error, _} = UrlPreview.fetch_url("http://localhost/")
+      after
+        Application.put_env(:mindwendel, :allow_private_ips, original_config)
+      end
     end
   end
 


### PR DESCRIPTION
## Further Notes

Hardens URL preview functionality to prevent SSRF (Server-Side Request Forgery) attacks and improves reliability of asynchronous link scanning.

  Security Improvements:
  - Blocks requests to private IP ranges (10.x.x.x, 172.16.x.x, 192.168.x.x, 169.254.x.x, 127.x.x.x) to prevent SSRF attacks
  targeting internal networks and cloud metadata endpoints
  - Validates URL scheme (only allows http/https)
  - Adds DNS resolution-based hostname validation
  - Implements request timeouts (5s timeout, 5s receive timeout)
  - Limits redirects to maximum of 3
  - Replaces unsupervised Task.start/1 with supervised Task.Supervisor.start_child/3 for link scanning
