### PR TITLE
refactor: sync tests and remove global stubs

### DIFF
--- a/lib/mindwendel/ai/config.ex
+++ b/lib/mindwendel/ai/config.ex
@@ -1,0 +1,15 @@
+defmodule Mindwendel.AI.Config do
+  @callback fetch_ai_config!() :: keyword()
+
+  def fetch_ai_config! do
+    impl().fetch_ai_config!()
+  end
+
+  defp impl do
+    Application.get_env(
+      :mindwendel,
+      :ai_config_service,
+      Mindwendel.AI.Config.DefaultImpl
+    )
+  end
+end

--- a/lib/mindwendel/ai/config/default_impl.ex
+++ b/lib/mindwendel/ai/config/default_impl.ex
@@ -1,0 +1,8 @@
+defmodule Mindwendel.AI.Config.DefaultImpl do
+  @behaviour Mindwendel.AI.Config
+
+  @impl Mindwendel.AI.Config
+  def fetch_ai_config! do
+    Application.fetch_env!(:mindwendel, :ai)
+  end
+end

--- a/lib/mindwendel/ai/token_tracking_service.ex
+++ b/lib/mindwendel/ai/token_tracking_service.ex
@@ -10,6 +10,7 @@ defmodule Mindwendel.AI.TokenTrackingService do
   """
 
   import Ecto.Query
+  alias Mindwendel.AI.Config
   alias Mindwendel.AI.TokenUsage
   alias Mindwendel.Repo
 
@@ -196,6 +197,6 @@ defmodule Mindwendel.AI.TokenTrackingService do
   end
 
   defp fetch_ai_config! do
-    Application.fetch_env!(:mindwendel, :ai)
+    Config.fetch_ai_config!()
   end
 end

--- a/lib/mindwendel/services/chat_completions/chat_completions_service_impl.ex
+++ b/lib/mindwendel/services/chat_completions/chat_completions_service_impl.ex
@@ -1,6 +1,7 @@
 defmodule Mindwendel.Services.ChatCompletions.ChatCompletionsServiceImpl do
   require Logger
 
+  alias Mindwendel.AI.Config
   alias Mindwendel.AI.Schemas.IdeaLabelAssignment
   alias Mindwendel.AI.Schemas.IdeaResponse
   alias Mindwendel.AI.TokenTrackingService
@@ -543,6 +544,6 @@ defmodule Mindwendel.Services.ChatCompletions.ChatCompletionsServiceImpl do
   end
 
   defp fetch_ai_config! do
-    Application.fetch_env!(:mindwendel, :ai)
+    Config.fetch_ai_config!()
   end
 end

--- a/lib/mindwendel/services/idea_service.ex
+++ b/lib/mindwendel/services/idea_service.ex
@@ -38,59 +38,56 @@ defmodule Mindwendel.Services.IdeaService do
           {:ok, list(Mindwendel.Brainstormings.Idea.t())} | {:error, atom()}
   def add_ideas_to_brainstorming(brainstorming) do
     if idea_generation_enabled?() do
-      do_add_ideas_to_brainstorming(brainstorming)
+      # Get current locale from Gettext for language-specific idea generation
+      locale = Gettext.get_locale(MindwendelWeb.Gettext)
+
+      # Get existing ideas to avoid duplicates
+      existing_ideas = Ideas.list_ideas_for_brainstorming(brainstorming.id)
+
+      with {:ok, default_lane_id} <- get_first_lane_id(brainstorming),
+           {:ok, generated_ideas} <-
+             ChatCompletionsService.generate_ideas(
+               brainstorming.name,
+               brainstorming.lanes,
+               existing_ideas,
+               locale
+             ) do
+        create_generated_ideas(brainstorming, generated_ideas, default_lane_id)
+      else
+        {:error, reason} ->
+          Logger.warning("Failed to generate ideas: #{inspect(reason)}")
+          {:error, reason}
+      end
     else
       {:ok, []}
     end
   end
 
-  defp do_add_ideas_to_brainstorming(brainstorming) do
-    # Get current locale from Gettext for language-specific idea generation
-    locale = Gettext.get_locale(MindwendelWeb.Gettext)
+  defp create_generated_ideas(brainstorming, generated_ideas, default_lane_id) do
+    valid_lane_ids = MapSet.new(Enum.map(brainstorming.lanes, & &1.id))
 
-    # Get existing ideas to avoid duplicates
-    existing_ideas = Ideas.list_ideas_for_brainstorming(brainstorming.id)
+    results =
+      Enum.map(generated_ideas, fn generated_idea ->
+        lane_id = resolve_lane_id(generated_idea["lane_id"], valid_lane_ids, default_lane_id)
 
-    with {:ok, default_lane_id} <- get_first_lane_id(brainstorming),
-         {:ok, generated_ideas} <-
-           ChatCompletionsService.generate_ideas(
-             brainstorming.name,
-             brainstorming.lanes,
-             existing_ideas,
-             locale
-           ) do
-      # Build a map of valid lane IDs for quick lookup
-      valid_lane_ids = MapSet.new(Enum.map(brainstorming.lanes, & &1.id))
+        Ideas.create_idea(%{
+          username: @ai_username,
+          body: generated_idea["idea"],
+          brainstorming_id: brainstorming.id,
+          lane_id: lane_id
+        })
+      end)
 
-      results =
-        Enum.map(generated_ideas, fn generated_idea ->
-          # Use the lane_id from AI if valid, otherwise fall back to default
-          lane_id = resolve_lane_id(generated_idea["lane_id"], valid_lane_ids, default_lane_id)
+    {successful, failed} = Enum.split_with(results, &match?({:ok, _}, &1))
 
-          Ideas.create_idea(%{
-            username: @ai_username,
-            body: generated_idea["idea"],
-            brainstorming_id: brainstorming.id,
-            lane_id: lane_id
-          })
-        end)
-
-      # Filter out failed creations and return only successful ones
-      {successful, failed} = Enum.split_with(results, &match?({:ok, _}, &1))
-
-      unless Enum.empty?(failed) do
-        Logger.warning(
-          "Failed to create #{length(failed)} ideas for brainstorming #{brainstorming.id}: #{inspect(failed)}"
-        )
-      end
-
-      successful_ideas = Enum.map(successful, fn {:ok, idea} -> idea end)
-      {:ok, successful_ideas}
-    else
-      {:error, reason} ->
-        Logger.warning("Failed to generate ideas: #{inspect(reason)}")
-        {:error, reason}
+    unless Enum.empty?(failed) do
+      Logger.warning(
+        "Failed to create #{length(failed)} ideas for brainstorming #{brainstorming.id}: #{inspect(failed)}"
+      )
     end
+
+    successful_ideas = Enum.map(successful, fn {:ok, idea} -> idea end)
+    {:ok, successful_ideas}
   end
 
   defp resolve_lane_id(nil, _valid_lane_ids, default_lane_id), do: default_lane_id

--- a/test/mindwendel/ai/token_tracking_service_test.exs
+++ b/test/mindwendel/ai/token_tracking_service_test.exs
@@ -1,5 +1,5 @@
 defmodule Mindwendel.AI.TokenTrackingServiceTest do
-  use Mindwendel.DataCase, async: false
+  use Mindwendel.DataCase, async: true
 
   alias Mindwendel.AI.TokenTrackingService
   alias Mindwendel.AI.TokenUsage
@@ -36,21 +36,14 @@ defmodule Mindwendel.AI.TokenTrackingServiceTest do
 
   describe "check_limits/0" do
     setup do
-      # Mock config for test
-      Application.put_env(:mindwendel, :ai,
-        enabled: true,
-        token_limit_daily: 1000,
-        token_limit_hourly: 100,
-        token_reset_hour: 0
-      )
-
-      on_exit(fn ->
-        # Restore test config from config/test.exs
-        Application.put_env(:mindwendel, :ai,
-          enabled: false,
-          token_limit_daily: nil,
-          token_limit_hourly: nil
-        )
+      Mindwendel.AI.Config.Mock
+      |> stub(:fetch_ai_config!, fn ->
+        [
+          enabled: true,
+          token_limit_daily: 1000,
+          token_limit_hourly: 100,
+          token_reset_hour: 0
+        ]
       end)
 
       :ok

--- a/test/mindwendel/services/chat_completions/chat_completions_service_impl_test.exs
+++ b/test/mindwendel/services/chat_completions/chat_completions_service_impl_test.exs
@@ -6,38 +6,31 @@ defmodule Mindwendel.Services.ChatCompletions.ChatCompletionsServiceImplTest do
 
   describe "generate_ideas/1" do
     setup do
-      # Configure AI for tests
-      Application.put_env(:mindwendel, :ai,
-        enabled: true,
-        provider: :openai,
-        model: "gpt-4o-mini",
-        api_key: "test-key",
-        token_limit_daily: 1000,
-        token_limit_hourly: 100,
-        request_timeout: 60_000
-      )
-
-      on_exit(fn ->
-        # Restore test config from config/test.exs
-        Application.put_env(:mindwendel, :ai,
-          enabled: false,
-          token_limit_daily: nil,
-          token_limit_hourly: nil,
+      Mindwendel.AI.Config.Mock
+      |> stub(:fetch_ai_config!, fn ->
+        [
+          enabled: true,
+          provider: :openai,
+          model: "gpt-4o-mini",
+          api_key: "test-key",
+          token_limit_daily: 1000,
+          token_limit_hourly: 100,
+          token_reset_hour: 0,
           request_timeout: 60_000
-        )
+        ]
       end)
 
       :ok
     end
 
     test "returns error when AI is not enabled" do
-      Application.put_env(:mindwendel, :ai, enabled: false)
+      Mindwendel.AI.Config.Mock
+      |> expect(:fetch_ai_config!, fn -> [enabled: false] end)
 
       assert {:error, :ai_not_enabled} = ChatCompletionsServiceImpl.generate_ideas("Test")
     end
 
     test "returns error when daily limit is exceeded" do
-      # Exceed daily limit
       {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 1001})
 
       assert {:error, :daily_limit_exceeded} =
@@ -45,7 +38,6 @@ defmodule Mindwendel.Services.ChatCompletions.ChatCompletionsServiceImplTest do
     end
 
     test "returns error when hourly limit is exceeded" do
-      # Exceed hourly limit
       {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 101})
 
       assert {:error, :hourly_limit_exceeded} =
@@ -55,37 +47,21 @@ defmodule Mindwendel.Services.ChatCompletions.ChatCompletionsServiceImplTest do
 
   describe "enabled?/0" do
     test "returns true when AI is enabled" do
-      Application.put_env(:mindwendel, :ai,
-        enabled: true,
-        token_limit_daily: nil,
-        token_limit_hourly: nil
-      )
+      Mindwendel.AI.Config.Mock
+      |> expect(:fetch_ai_config!, fn ->
+        [enabled: true, token_limit_daily: nil, token_limit_hourly: nil]
+      end)
 
       assert ChatCompletionsServiceImpl.enabled?() == true
     end
 
     test "returns false when AI is disabled" do
-      Application.put_env(:mindwendel, :ai,
-        enabled: false,
-        token_limit_daily: nil,
-        token_limit_hourly: nil
-      )
+      Mindwendel.AI.Config.Mock
+      |> expect(:fetch_ai_config!, fn ->
+        [enabled: false, token_limit_daily: nil, token_limit_hourly: nil]
+      end)
 
       assert ChatCompletionsServiceImpl.enabled?() == false
-    end
-
-    test "raises ArgumentError when AI config is missing" do
-      # Temporarily delete config to test error handling
-      original_config = Application.get_env(:mindwendel, :ai)
-      Application.delete_env(:mindwendel, :ai)
-
-      # enabled?() should raise because it calls fetch_ai_config!() which uses Application.fetch_env!
-      assert_raise ArgumentError, fn ->
-        ChatCompletionsServiceImpl.enabled?()
-      end
-
-      # Restore config
-      Application.put_env(:mindwendel, :ai, original_config || [enabled: false])
     end
   end
 

--- a/test/mindwendel_web/live/brainstorming_live_ai_token_limit_test.exs
+++ b/test/mindwendel_web/live/brainstorming_live_ai_token_limit_test.exs
@@ -14,7 +14,6 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
   import Mindwendel.BrainstormingsFixtures
 
   alias Mindwendel.Accounts
-  alias Mindwendel.AI.TokenTrackingService
 
   describe "AI generation with token limits" do
     setup do
@@ -35,10 +34,8 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
       brainstorming: brainstorming,
       moderating_user: moderating_user
     } do
-      # Exceed daily token limit
-      {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 1_000_001})
+      mock_generate_ideas_error(:daily_limit_exceeded)
 
-      # Mount the LiveView with moderating user
       {:ok, view, _html} =
         conn
         |> init_test_session(%{current_user_id: moderating_user.id})
@@ -46,15 +43,12 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
 
       allow_chat_completions(view.pid)
 
-      # Trigger AI idea generation
       view |> element("button[phx-click='generate_ai_ideas']") |> render_click()
 
-      # Wait for async message to be processed
       :timer.sleep(200)
 
-      # Verify an error message is displayed (generic error due to mock setup)
       html = render(view)
-      assert html =~ "Failed to generate ideas"
+      assert html =~ "Daily AI token limit exceeded"
     end
 
     test "shows appropriate error message when hourly token limit is exceeded", %{
@@ -62,10 +56,8 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
       brainstorming: brainstorming,
       moderating_user: moderating_user
     } do
-      # Exceed hourly token limit
-      {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 100_001})
+      mock_generate_ideas_error(:hourly_limit_exceeded)
 
-      # Mount the LiveView with moderating user
       {:ok, view, _html} =
         conn
         |> init_test_session(%{current_user_id: moderating_user.id})
@@ -73,15 +65,12 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
 
       allow_chat_completions(view.pid)
 
-      # Trigger AI idea generation
       view |> element("button[phx-click='generate_ai_ideas']") |> render_click()
 
-      # Wait for async message to be processed
       :timer.sleep(200)
 
-      # Verify an error message is displayed (generic error due to mock setup)
       html = render(view)
-      assert html =~ "Failed to generate ideas"
+      assert html =~ "Hourly AI request limit exceeded"
     end
 
     test "replaces loading message with error when limit is hit", %{
@@ -89,10 +78,8 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
       brainstorming: brainstorming,
       moderating_user: moderating_user
     } do
-      # Exceed daily token limit
-      {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 1_000_001})
+      mock_generate_ideas_error(:daily_limit_exceeded)
 
-      # Mount the LiveView with moderating user
       {:ok, view, _html} =
         conn
         |> init_test_session(%{current_user_id: moderating_user.id})
@@ -100,7 +87,6 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
 
       allow_chat_completions(view.pid)
 
-      # Trigger AI idea generation
       click_html =
         view
         |> element("button[phx-click='generate_ai_ideas']")
@@ -112,9 +98,9 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
       # Wait for async message to process
       :timer.sleep(200)
 
-      # Error message should appear (generic error due to mock setup)
+      # Error message should appear
       html = render(view)
-      assert html =~ "Failed to generate ideas"
+      assert html =~ "Daily AI token limit exceeded"
     end
 
     test "successfully generates ideas when within limits", %{
@@ -122,10 +108,8 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
       brainstorming: brainstorming,
       moderating_user: moderating_user
     } do
-      # Mock successful AI generation with 3 ideas
       mock_generate_ideas(3)
 
-      # Mount the LiveView with moderating user
       {:ok, view, _html} =
         conn
         |> init_test_session(%{current_user_id: moderating_user.id})
@@ -133,25 +117,19 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
 
       allow_chat_completions(view.pid)
 
-      # Trigger AI idea generation
       view |> element("button[phx-click='generate_ai_ideas']") |> render_click()
 
-      # Wait for async processing
       :timer.sleep(200)
 
-      # Verify success message
       html = render(view)
       assert html =~ "idea(s) generated"
     end
 
     test "hides AI button when AI is disabled", %{conn: conn, brainstorming: brainstorming} do
-      # Disable AI
       disable_ai()
 
-      # Mount the LiveView
       {:ok, view, _html} = live(conn, ~p"/brainstormings/#{brainstorming.id}")
 
-      # Verify AI button is not shown
       refute view |> has_element?("button[phx-click='generate_ai_ideas']")
     end
   end
@@ -163,24 +141,19 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
       Mindwendel.Services.ChatCompletions.ChatCompletionsServiceMock
       |> stub(:enabled?, fn -> true end)
 
-      # Get moderating user from brainstorming
       moderating_user = List.first(brainstorming.users)
       Accounts.add_moderating_user(brainstorming, moderating_user)
 
       %{brainstorming: brainstorming, moderating_user: moderating_user}
     end
 
-    test "allows generation when at exactly the daily limit minus one", %{
+    test "allows generation when within limits", %{
       conn: conn,
       brainstorming: brainstorming,
       moderating_user: moderating_user
     } do
-      # Set usage to just under the limit (999,999 tokens)
-      {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 999_999})
-
       mock_generate_ideas(2)
 
-      # Mount the LiveView with moderating user
       {:ok, view, _html} =
         conn
         |> init_test_session(%{current_user_id: moderating_user.id})
@@ -188,27 +161,22 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
 
       allow_chat_completions(view.pid)
 
-      # Trigger AI idea generation - should succeed
       view |> element("button[phx-click='generate_ai_ideas']") |> render_click()
 
-      # Wait for async processing
       :timer.sleep(200)
 
-      # Verify success (no error message about limits)
       html = render(view)
       refute html =~ "Daily AI token limit exceeded"
       refute html =~ "Hourly AI request limit exceeded"
     end
 
-    test "blocks generation when at exactly the daily limit", %{
+    test "blocks generation when daily limit is reached", %{
       conn: conn,
       brainstorming: brainstorming,
       moderating_user: moderating_user
     } do
-      # Set usage to exactly the limit (1,000,000 tokens)
-      {:ok, _} = TokenTrackingService.record_usage(%{total_tokens: 1_000_000})
+      mock_generate_ideas_error(:daily_limit_exceeded)
 
-      # Mount the LiveView with moderating user
       {:ok, view, _html} =
         conn
         |> init_test_session(%{current_user_id: moderating_user.id})
@@ -216,15 +184,12 @@ defmodule MindwendelWeb.BrainstormingLiveAITokenLimitTest do
 
       allow_chat_completions(view.pid)
 
-      # Trigger AI idea generation - should be blocked
       view |> element("button[phx-click='generate_ai_ideas']") |> render_click()
 
-      # Wait for async processing
       :timer.sleep(200)
 
-      # Verify error message (generic error due to mock setup)
       html = render(view)
-      assert html =~ "Failed to generate ideas"
+      assert html =~ "Daily AI token limit exceeded"
     end
   end
 

--- a/test/support/chat_completions_case.ex
+++ b/test/support/chat_completions_case.ex
@@ -36,6 +36,17 @@ defmodule Mindwendel.ChatCompletionsCase do
   end
 
   defp stub_ai_disabled do
+    Mindwendel.AI.Config.Mock
+    |> stub(:fetch_ai_config!, fn ->
+      [
+        enabled: false,
+        token_limit_daily: nil,
+        token_limit_hourly: nil,
+        token_reset_hour: 0,
+        request_timeout: 60_000
+      ]
+    end)
+
     Mindwendel.Services.ChatCompletions.ChatCompletionsServiceMock
     |> stub(:enabled?, fn -> false end)
     |> stub(:generate_ideas, fn _title, _lanes, _existing_ideas, _locale ->

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -56,6 +56,17 @@ defmodule MindwendelWeb.ConnCase do
   # Provide default AI disabled stub for all ConnCase tests
   # This prevents Mox.UnexpectedCallError when LiveViews render
   defp setup_ai_disabled_stub(_context) do
+    Mindwendel.AI.Config.Mock
+    |> Mox.stub(:fetch_ai_config!, fn ->
+      [
+        enabled: false,
+        token_limit_daily: nil,
+        token_limit_hourly: nil,
+        token_reset_hour: 0,
+        request_timeout: 60_000
+      ]
+    end)
+
     Mindwendel.Services.ChatCompletions.ChatCompletionsServiceMock
     |> Mox.stub(:enabled?, fn -> false end)
     |> Mox.stub(:generate_ideas, fn _title, _lanes, _existing_ideas, _locale ->

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -48,6 +48,17 @@ defmodule Mindwendel.DataCase do
 
   # Provide default AI disabled stub for all DataCase tests
   defp setup_ai_disabled_stub(_context) do
+    Mindwendel.AI.Config.Mock
+    |> Mox.stub(:fetch_ai_config!, fn ->
+      [
+        enabled: false,
+        token_limit_daily: nil,
+        token_limit_hourly: nil,
+        token_reset_hour: 0,
+        request_timeout: 60_000
+      ]
+    end)
+
     Mindwendel.Services.ChatCompletions.ChatCompletionsServiceMock
     |> Mox.stub(:enabled?, fn -> false end)
     |> Mox.stub(:generate_ideas, fn _title, _lanes, _existing_ideas, _locale ->

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,15 +5,19 @@ Ecto.Adapters.SQL.Sandbox.mode(Mindwendel.Repo, :manual)
 upload_path = "priv/static/uploads/"
 File.mkdir_p!(Path.dirname(upload_path))
 
-# Define the mock - it will be configured per-test via test case setups
+# Define mocks - they will be configured per-test via test case setups
 Mox.defmock(Mindwendel.Services.ChatCompletions.ChatCompletionsServiceMock,
   for: Mindwendel.Services.ChatCompletions.ChatCompletionsService
 )
 
-# Configure to use the mock in tests
+Mox.defmock(Mindwendel.AI.Config.Mock, for: Mindwendel.AI.Config)
+
+# Configure to use mocks in tests
 # Each test case (ChatCompletionsCase, ConnCase, DataCase) will set up appropriate stubs/expectations
 Application.put_env(
   :mindwendel,
   :chat_completions_service,
   Mindwendel.Services.ChatCompletions.ChatCompletionsServiceMock
 )
+
+Application.put_env(:mindwendel, :ai_config_service, Mindwendel.AI.Config.Mock)


### PR DESCRIPTION
## Further Notes

- Fix flaky failing tests due to async tests in combination with modifying global testing setup (env vars)
- Use mocks instead of env vars for testing by introduction of a config service
