### PR TITLE
fix: add oban v13 migration and fix v12 down

### DIFF
--- a/priv/repo/migrations/20240104163948_upgrade_oban_jobs_to_v12.exs
+++ b/priv/repo/migrations/20240104163948_upgrade_oban_jobs_to_v12.exs
@@ -3,5 +3,5 @@ defmodule Mindwendel.Repo.Migrations.UpgradeObanJobsToV12 do
 
   def up, do: Oban.Migrations.up(version: 12)
 
-  def down, do: Oban.Migrations.down(version: 11)
+  def down, do: Oban.Migrations.down(version: 12)
 end

--- a/priv/repo/migrations/20260319111230_upgrade_oban_jobs_to_v13.exs
+++ b/priv/repo/migrations/20260319111230_upgrade_oban_jobs_to_v13.exs
@@ -1,0 +1,7 @@
+defmodule Mindwendel.Repo.Migrations.UpgradeObanJobsToV13 do
+  use Ecto.Migration
+
+  def up, do: Oban.Migrations.up(version: 13)
+
+  def down, do: Oban.Migrations.down(version: 13)
+end


### PR DESCRIPTION
## Further Notes

- Add Oban v13 migration and fix v12 down migration which was using a wrong version number