### PR TITLE
chore: upgrade elixir, otp and debian

### DIFF
--- a/.github/workflows/on_push_branch__execute_ci_cd.yml
+++ b/.github/workflows/on_push_branch__execute_ci_cd.yml
@@ -17,7 +17,7 @@ jobs:
     # Currently, this need to be synced manually with the Dockerfile. In the future, the workflow should be changed,
     # so that a development container is built from the Dockerfile, pushed, and then re-used in the following steps.
     # This would also remove the need to install cmake manually in each step:
-    container: hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241111-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.11-debian-bookworm-20260518-slim
 
     steps:
       # See https://github.com/actions/checkout
@@ -41,7 +41,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241111-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.11-debian-bookworm-20260518-slim
 
     needs: build_deps
 
@@ -97,7 +97,7 @@ jobs:
 
   check_mix_format:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241111-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.11-debian-bookworm-20260518-slim
 
     needs: build_deps
 
@@ -118,7 +118,7 @@ jobs:
 
   check_mix_gettext_extract_up_to_date:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241111-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.11-debian-bookworm-20260518-slim
 
     needs: build_deps
 
@@ -139,7 +139,7 @@ jobs:
 
   check_mix_sobelow:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241111-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.11-debian-bookworm-20260518-slim
 
     needs: build_deps
 
@@ -161,7 +161,7 @@ jobs:
 
   check_mix_credo:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.17.3-erlang-27.1.2-debian-bookworm-20241111-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.11-debian-bookworm-20260518-slim
 
     needs: build_deps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE} AS production
 
-RUN apt-get update -y && apt-get install -y ca-certificates libstdc++6 postgresql-client openssl libncurses5 locales \
+RUN apt-get update -y && apt-get install -y ca-certificates libstdc++6 postgresql-client openssl libncurses6 locales \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.1-erlang-24.2-debian-bullseye-20210902-slim
 #
-ARG ELIXIR_VERSION=1.17.3
-ARG OTP_VERSION=27.1.2
-ARG DEBIAN_VERSION=bookworm-20241111-slim
+ARG ELIXIR_VERSION=1.18.4
+ARG OTP_VERSION=27.3.4.11
+ARG DEBIAN_VERSION=bookworm-20260518-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -20,20 +20,20 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.8.5",
+      "version": "1.8.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "7.28.6",
         "@babel/core": "7.29.0",
-        "@babel/preset-env": "7.29.0",
+        "@babel/preset-env": "7.29.3",
         "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.0.0",
         "documentation": "^14.0.3",
-        "eslint": "10.0.2",
-        "eslint-plugin-jest": "29.15.0",
+        "eslint": "10.2.1",
+        "eslint-plugin-jest": "29.15.2",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
-        "jsdom": "^28.1.0",
+        "jsdom": "^29.0.1",
         "mock-socket": "^9.3.1"
       }
     },
@@ -41,7 +41,7 @@
       "version": "4.3.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "1.1.27",
+      "version": "1.1.30",
       "license": "MIT",
       "dependencies": {
         "morphdom": "2.7.8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,12 +51,8 @@ services:
       - "${DOCKER_COMPOSE_APP_PORT_PUBLISHED:-4000}:${DOCKER_COMPOSE_APP_PORT_TARGET:-4000}"
     depends_on:
       - postgres
-    # Mount the lib and test folder to increase development speed (do not use for prod setups!)
     volumes:
-      - ./:/app
-      - /app/_build/
-      - deps:/app/deps
-      - /app/assets/node_modules
+      - ./:/home/elixir/app
 
   minio:
     image: minio/minio

--- a/lib/mindwendel/ai/token_tracking_service.ex
+++ b/lib/mindwendel/ai/token_tracking_service.ex
@@ -98,7 +98,7 @@ defmodule Mindwendel.AI.TokenTrackingService do
   @doc """
   Cleans up old usage records (older than 90 days).
   """
-  @spec cleanup_old_records() :: {:ok, integer()}
+  @spec cleanup_old_records() :: {:ok, integer()} | {:error, term()}
   def cleanup_old_records do
     cutoff = DateTime.utc_now() |> DateTime.add(-90, :day)
 
@@ -108,6 +108,8 @@ defmodule Mindwendel.AI.TokenTrackingService do
       |> Repo.delete_all()
 
     {:ok, count}
+  rescue
+    error -> {:error, error}
   end
 
   # Private functions


### PR DESCRIPTION
## Further Notes

This PR upgrades elixir, otp and debian:

ARG ELIXIR_VERSION=1.18.4
ARG OTP_VERSION=27.3.4.11
ARG DEBIAN_VERSION=bookworm-20260518-slim